### PR TITLE
Add feature

### DIFF
--- a/Controller/Adminhtml/System/HistoricalOrders/Download.php
+++ b/Controller/Adminhtml/System/HistoricalOrders/Download.php
@@ -103,7 +103,7 @@ class Download extends \Magento\Backend\App\Action
             ->add(new \DateInterval('P1D'))
             ->sub(new \DateInterval('PT1S'));
 
-        $feedData = $this->ordersModel->getOrdersFeed($storeId, $fromDate, $toDate);
+        $feedData = $this->ordersModel->getOrdersFeed($storeId, $fromDate, $toDate, true);
 
         return $this->fileFactory->create(
             self::DOWNLOAD_FILENAME,

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -118,6 +118,8 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
     const XML_PATH_SOCIALCOMMERCE_FEED_SUBMISSION_URL = 'turnto_socialcommerce_configuration/product_feed/feed_submission_url';
 
     const XML_PATH_SOCIALCOMMERCE_HISTORICAL_FEED_ENABLED = 'turnto_socialcommerce_configuration/historical_orders_feed/enable_historical_feed';
+
+    const XML_PATH_SOCIALCOMMERCE_EXCLUDE_ITEMS_WITHOUT_DELIVERY_DATE = 'turnto_socialcommerce_configuration/historical_orders_feed/exclude_items_without_delivery_date';
     
     const XML_PATH_EXPORT_FEED_URL = 'turnto_socialcommerce_configuration/product_feed/product_feed_url';
 
@@ -599,6 +601,19 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
             self::XML_PATH_SOCIALCOMMERCE_HISTORICAL_FEED_ENABLED,
             ScopeInterface::SCOPE_STORE,
             $store ? $store : $this->getCurrentStoreCode()
+        );
+    }
+
+    /**
+     * @param $store
+     * @return mixed
+     */
+    public function getExcludeItemsWithoutDeliveryDate($store)
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_SOCIALCOMMERCE_EXCLUDE_ITEMS_WITHOUT_DELIVERY_DATE,
+            ScopeInterface::SCOPE_STORE,
+            $store
         );
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -316,6 +316,14 @@
                         <field id="turnto_socialcommerce_configuration/general/enabled">1</field>
                     </depends>
                 </field>
+                <field id="exclude_items_without_delivery_date" type="select" translate="label" sortOrder="20" showInStore="1" showInWebsite="1" showInDefault="1">
+                    <label>Exclude Items Without a Delivery Date</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="turnto_socialcommerce_configuration/general/enabled">1</field>
+                        <field id="turnto_socialcommerce_configuration/historical_orders_feed/enable_historical_feed">1</field>
+                    </depends>
+                </field>
             </group>
         </section>
     </system>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -64,6 +64,7 @@
             </product_feed>
             <historical_orders_feed>
                 <enable_historical_feed>1</enable_historical_feed>
+                <exclude_items_without_delivery_date>0</exclude_items_without_delivery_date>
             </historical_orders_feed>
         </turnto_socialcommerce_configuration>
     </default>


### PR DESCRIPTION
- New feature allows a user to exclude items in an order that do not
have a delivery date set on that item when running the
socialcommerce_exportorders cronjob.