### PR TITLE
Fixed issue with wrong star count when last start is half star in tea…

### DIFF
--- a/view/frontend/web/js/teaser.js
+++ b/view/frontend/web/js/teaser.js
@@ -68,7 +68,7 @@ define([
         },
 
         getNumEmptyStars: function getNumEmptyStars() {
-            return 5 - this.getNumFullStars() + (this.hasHalfStar() ? 1 : 0);
+            return 5 - (this.getNumFullStars() + (this.hasHalfStar() ? 1 : 0));
         },
 
         writeReview: function writeReview() {


### PR DESCRIPTION
This is a fix for bug with wrong star count when last star is half star.  This bug causes showing 8 stars instead of 5.

![Screen Shot 2019-06-26 at 10 42 30](https://user-images.githubusercontent.com/16260098/60165201-37322a80-97ff-11e9-9a78-0396b2dc3600.png)

After fix:

![Screen Shot 2019-06-26 at 10 52 44](https://user-images.githubusercontent.com/16260098/60165959-917fbb00-9800-11e9-8660-19f3ab4007bc.png)
