### PR TITLE
Fix for issue #91

### DIFF
--- a/Plugin/Review/Block/Product/ReviewRenderer.php
+++ b/Plugin/Review/Block/Product/ReviewRenderer.php
@@ -39,8 +39,8 @@ class ReviewRenderer
      * @var array
      */
     protected $_availableTemplates = [
-        \Magento\Catalog\Block\Product\ReviewRendererInterface::FULL_VIEW => 'helper/summary.phtml',
-        \Magento\Catalog\Block\Product\ReviewRendererInterface::SHORT_VIEW => 'helper/summary_short.phtml',
+        \Magento\Catalog\Block\Product\ReviewRendererInterface::FULL_VIEW => 'Magento_Review::helper/summary.phtml',
+        \Magento\Catalog\Block\Product\ReviewRendererInterface::SHORT_VIEW => 'Magento_Review::helper/summary_short.phtml',
     ];
 
     /**


### PR DESCRIPTION
Issuer suggested our lack of namespacing on template names was causing issues for other modules plugging into the same class. I wasn't able to reproduce their issue, but I believe the namespacing is best practice anyway, so this commit adds it to class Plugin/Review/Block/Product/ReviewRenderer.php