### PR TITLE
Update teaser.js

### DIFF
--- a/view/frontend/web/js/teaser.js
+++ b/view/frontend/web/js/teaser.js
@@ -62,12 +62,12 @@ define([
 
         getNumFullStars: function getFullStars() {
             //if the reviews are 4.8 or above return 5 else return the reviews
-            return Math.floor(this.reviewsData().avgRating) >= 4.8 ? 5 : Math.floor(this.reviewsData().avgRating);
+            return Math.floor(this.reviewsData().avgRating) >= 4.75 ? 5 : Math.floor(this.reviewsData().avgRating);
         },
 
         hasHalfStar: function hasHalfStar() {
-            let halfStarValue = (this.reviewsData().avgRating - this.getNumFullStars()).toFixed(1);
-            return halfStarValue >= 0.3 && halfStarValue <= .7;
+            let halfStarValue = (this.reviewsData().avgRating - this.getNumFullStars()).toFixed(2);
+            return halfStarValue > 0.25 && halfStarValue <= .75;
         },
 
         getNumEmptyStars: function getNumEmptyStars() {


### PR DESCRIPTION
I was looking into an issue (https://turnto.zendesk.com/agent/tickets/52278) where a customer saw that the teaser was showing a different number of stars than our widgets. At first I thought this was code they had written, but then learned it was from our extension.

For an item with an average rating of 4.79, the teaser was showing 4 stars, while our widgets were showing 5. I spoke with Russ, and he confirmed that our widgets use .25 and 0.75 as the cutoffs for showing half stars and full stars.

The problematic code in question:

```
getNumFullStars: function getFullStars() {
  return Math.floor(this.reviewsData().avgRating) >= 4.8 ? 5 : Math.floor(this.reviewsData().avgRating);
},
hasHalfStar: function hasHalfStar() {
  let halfStarValue = (this.reviewsData().avgRating - this.getNumFullStars()).toFixed(1);
  return halfStarValue >= 0.3 && halfStarValue <= .7;
},
```
4.79 as the `avgRating` means that `getNumFullStars` returns `4`. Then `halfStarValue` evaluates to `0.8`. And as such `hasHalfStar` returns `false`, which his how the teaser ends ups showing only 4 stars for an item with a 4.79 rating.

This PR just updates the numbers to use more accurate boundaries that are consistent with our widgets.