### PR TITLE
change average-rating-import to average_rating_import

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -102,9 +102,9 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
 
     const XML_PATH_SOCIALCOMMERCE_HISTORICAL_FEED_ENABLED = 'turnto_socialcommerce_configuration/historical_orders_feed/enable_historical_feed';
 
-    const XML_PATH_SOCIALCOMMERCE_AVERAGE_RATING_IMPORT_ENABLED = 'turnto_socialcommerce_configuration/average-rating-import/enable_average_rating';
+    const XML_PATH_SOCIALCOMMERCE_AVERAGE_RATING_IMPORT_ENABLED = 'turnto_socialcommerce_configuration/average_rating_import/enable_average_rating';
 
-    const XML_PATH_SOCIALCOMMERCE_AVERAGE_RATING_IMPORT_AGGREGATE_DATA = 'turnto_socialcommerce_configuration/average-rating-import/import_aggregate_data';
+    const XML_PATH_SOCIALCOMMERCE_AVERAGE_RATING_IMPORT_AGGREGATE_DATA = 'turnto_socialcommerce_configuration/average_rating_import/import_aggregate_data';
 
     const XML_PATH_SOCIALCOMMERCE_CANCELLED_FEED_ENABLED = 'turnto_socialcommerce_configuration/historical_orders_feed/enable_cancelled_feed';
 


### PR DESCRIPTION
The change should follow with #179 in `etc/adminhtml/system.xml` [line 362](https://github.com/turnto/magento2-turnto-socialcommerce/blob/bbc793ebabfdacc810613746325187494b9588a3/etc/adminhtml/system.xml#L362)

Change group id in xml from `average-rating-import` to `average_rating_import`