### PR TITLE
fix a couple stray errors in the average rating and catalog feeds

### DIFF
--- a/Model/Export/Catalog.php
+++ b/Model/Export/Catalog.php
@@ -397,8 +397,7 @@ class Catalog extends AbstractExport
         if (!$productHasImage) {
             $productImageUrl = '';
         } else {
-            $imageHelper = $this->getImageHelper();
-            $productImageUrl = $imageHelper->init($product, 'product_page_main_image')->setImageFile(
+            $productImageUrl = $this->imageHelper->init($product, 'product_page_main_image')->setImageFile(
                 $product->getImage()
             )->getUrl();
             $productImageUrl = str_replace(" ", "-", $productImageUrl);

--- a/Model/Import/Ratings.php
+++ b/Model/Import/Ratings.php
@@ -235,7 +235,7 @@ class Ratings extends AbstractImport
                             );
                         }
                         // Now reset all products not in the feed
-                        $this->resetProducts($feedProducts);
+                        $this->resetProducts($feedProducts, $store);
                     }
                 } catch (\Exception $feedRetrievalException) {
                     $this->logger->error(


### PR DESCRIPTION
Client noted two specific errors:

- Average Rating Feed
ERROR: Cron Job socialcommerce_importratings has an error: Too few arguments to function TurnTo\SocialCommerce\Model\Import\Ratings::resetProducts(), 1 passed in /var/www/releases/1623956839/vendor/turnto/social-commerce/Model/Import/Ratings.php on line 238 and exactly 2 expected. 

- Catalog Feed
ERROR: Cron Job socialcommerce_exportcatalog has an error: Call to undefined method TurnTo\SocialCommerce\Model\Export\Catalog::getImageHelper().