### PR TITLE
fix str_replace order so it does the right thing

### DIFF
--- a/Model/Export/Catalog.php
+++ b/Model/Export/Catalog.php
@@ -330,7 +330,7 @@ class Catalog extends AbstractExport
         if (empty($productName)) {
             throw new \Exception('Product must have a valid name');
         }
-        $productName = str_replace($productName, "\n", "");
+        $productName = str_replace("\n", "", $productName);
 
         $entry->addChild('id', $this->sanitizeData($sku));
 


### PR DESCRIPTION
Fixes an issue where I messed up the string replace and instead of removing new lines, it blanks out the product title