### PR TITLE
move the pdp config block below the regular turnto config block

### DIFF
--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -26,13 +26,13 @@
                         <item name="chatter" xsi:type="array"/>
                     </argument>
                 </arguments>Magento\Catalog\Block\Product\View
-                <block class="TurnTo\SocialCommerce\Block\Config" name="turnto.pdp" template="TurnTo_SocialCommerce::product/view/config.phtml">
-                    <arguments>
-                        <argument name="data" xsi:type="array">
-                            <item name="cache_lifetime" xsi:type="number">3600</item>
-                        </argument>
-                    </arguments>
-                </block>
+            </block>
+            <block class="TurnTo\SocialCommerce\Block\Config" name="turnto.pdp" template="TurnTo_SocialCommerce::product/view/config.phtml">
+                <arguments>
+                    <argument name="data" xsi:type="array">
+                        <item name="cache_lifetime" xsi:type="number">3600</item>
+                    </argument>
+                </arguments>
             </block>
         </referenceContainer>
 


### PR DESCRIPTION
Moving pdp config block below regular turnto config block in layout file to make sure TurnToCmd gets called after turnToConfig and other required js is defined.