### PR TITLE
move average rating feed reset function call outside of produt loop

### DIFF
--- a/Model/Import/Ratings.php
+++ b/Model/Import/Ratings.php
@@ -234,9 +234,9 @@ class Ratings extends AbstractImport
                                 ]
                             );
                         }
-                        // Now reset all products not in the feed
-                        $this->resetProducts($feedProducts, $store);
                     }
+                    // Now reset all products not in the feed
+                    $this->resetProducts($feedProducts, $store);
                 } catch (\Exception $feedRetrievalException) {
                     $this->logger->error(
                         'Failed to retrieve TurnTo aggregate rating feed for store from TurnTo',


### PR DESCRIPTION
The `reset` function, which is responsible for setting products' Average Rating/Review Count values to 0 if the product isn't in the Average Rating Feed, was getting called after every single product entry that was processed. Instead it should only be called once at the end.