### PR TITLE
TSD-93/updates for 2.4.3

### DIFF
--- a/Block/Widget/LandingPage.php
+++ b/Block/Widget/LandingPage.php
@@ -48,7 +48,7 @@ class LandingPage extends \Magento\Framework\View\Element\Template implements \M
         }
 
         $landingPageBlock->setConfigData(['pageId' => 'email-landing-page']);
-        
+
         return $landingPageBlock->toHtml();
     }
 

--- a/Block/Widget/LandingPage.php
+++ b/Block/Widget/LandingPage.php
@@ -37,11 +37,6 @@ class LandingPage extends \Magento\Framework\View\Element\Template implements \M
      */
     public function getTurnToConfigHtml()
     {
-        $writer = new \Zend\Log\Writer\Stream(BP . '/var/log/test-custom.log');
-        $logger = new \Zend\Log\Logger();
-        $logger->addWriter($writer);
-        $logger->info('getTurnToConfigHtml');
-
         /** @var \TurnTo\SocialCommerce\Block\TurnToConfig $landingPageBlock */
         try {
             $landingPageBlock = $this->getLayout()->createBlock(

--- a/Block/Widget/LandingPage.php
+++ b/Block/Widget/LandingPage.php
@@ -48,9 +48,7 @@ class LandingPage extends \Magento\Framework\View\Element\Template implements \M
         }
 
         $landingPageBlock->setConfigData(['pageId' => 'email-landing-page']);
-
-        $logger->info('getTurnToConfigHtml: ' . $landingPageBlock->toHtml());
-
+        
         return $landingPageBlock->toHtml();
     }
 

--- a/Controller/Ajax/Media.php
+++ b/Controller/Ajax/Media.php
@@ -174,29 +174,32 @@ class Media extends \Magento\Swatches\Controller\Ajax\Media
         // End Edit
 
         $productMedia = [];
+
+        /** @var \Magento\Framework\Controller\Result\Json $resultJson */
+        $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
+
+        /** @var \Magento\Framework\App\ResponseInterface $response */
+        $response = $this->getResponse();
+
         if ($productId = (int)$this->getRequest()->getParam('product_id')) {
-            $currentConfigurable = $this->productModelFactory->create()->load($productId);
-            $attributes = (array)$this->getRequest()->getParam('attributes');
-            if (!empty($attributes)) {
-                $product = $this->getProductVariationWithMedia($currentConfigurable, $attributes);
+            /** @var \Magento\Catalog\Api\Data\ProductInterface $product */
+            $product = $this->productModelFactory->create()->load($productId);
+            $productMedia = [];
+            if ($product->getId() && $product->getStatus() == Status::STATUS_ENABLED) {
+                $productMedia = $this->swatchHelper->getProductMediaGallery($product);
             }
-            if ((empty($product) || (!$product->getImage() || $product->getImage() == 'no_selection'))
-                && isset($currentConfigurable)
-            ) {
-                $product = $currentConfigurable;
-            }
-            $productMedia = $this->swatchHelper->getProductMediaGallery($product);
+            $resultJson->setHeader('X-Magento-Tags', implode(',', $product->getIdentities()));
+
+            $response->setPublicHeaders($this->config->getTtl());
 
             // Begin Edit
-            $childProduct = $this->swatchHelper->loadVariationByFallback($product, $attributes);
+            $childProduct = $this->swatchHelper->loadVariationByFallback($product);
             $productMedia['sku'] = $this->productHelper->turnToSafeEncoding(
                 $childProduct ? $childProduct->getSku() : $product->getSku()
             );
             // End Edit
         }
 
-        /** @var \Magento\Framework\Controller\Result\Json $resultJson */
-        $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
         $resultJson->setData($productMedia);
 
         return $resultJson;

--- a/Controller/Ajax/Media.php
+++ b/Controller/Ajax/Media.php
@@ -17,6 +17,7 @@ namespace TurnTo\SocialCommerce\Controller\Ajax;
 
 use Magento\Framework\Controller\ResultFactory;
 use TurnTo\SocialCommerce\Helper\Product;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
 
 class Media extends \Magento\Swatches\Controller\Ajax\Media
 {

--- a/Model/Config/Source/AddressFallback.php
+++ b/Model/Config/Source/AddressFallback.php
@@ -19,7 +19,7 @@ namespace TurnTo\SocialCommerce\Model\Config\Source;
  * Class ProductAttributeSelect
  * @package TurnTo\SocialCommerce\Model\Config\Source
  */
-class AddressFallback implements \Magento\Framework\Option\ArrayInterface
+class AddressFallback implements \Magento\Framework\Data\OptionSourceInterface
 {
 
     CONST BILLING_ADDRESS_VALUE = '0';

--- a/Model/Config/Source/ProductAttributeSelect.php
+++ b/Model/Config/Source/ProductAttributeSelect.php
@@ -19,7 +19,7 @@ namespace TurnTo\SocialCommerce\Model\Config\Source;
  * Class ProductAttributeSelect
  * @package TurnTo\SocialCommerce\Model\Config\Source
  */
-class ProductAttributeSelect implements \Magento\Framework\Option\ArrayInterface
+class ProductAttributeSelect implements \Magento\Framework\Data\OptionSourceInterface
 {
     /**
      * @var null|\TurnTo\SocialCommerce\Helper\Config

--- a/Model/Config/Source/TeaserType.php
+++ b/Model/Config/Source/TeaserType.php
@@ -19,7 +19,7 @@ namespace TurnTo\SocialCommerce\Model\Config\Source;
  * Class ProductAttributeSelect
  * @package TurnTo\SocialCommerce\Model\Config\Source
  */
-class TeaserType implements \Magento\Framework\Option\ArrayInterface
+class TeaserType implements \Magento\Framework\Data\OptionSourceInterface
 {
 
     /**

--- a/view/frontend/templates/widget/landing_page.phtml
+++ b/view/frontend/templates/widget/landing_page.phtml
@@ -15,10 +15,5 @@
 
 /** @var \TurnTo\SocialCommerce\Block\Widget\LandingPage $block */
 echo $block->getTurnToConfigHtml();
-
-$writer = new \Zend\Log\Writer\Stream(BP . '/var/log/test-custom.log');
-$logger = new \Zend\Log\Logger();
-$logger->addWriter($writer);
-$logger->info('inside template');
 ?>
 <div id="tt-embedded-submission"></div>

--- a/view/frontend/web/js/swatch-renderer-mixin.js
+++ b/view/frontend/web/js/swatch-renderer-mixin.js
@@ -36,8 +36,8 @@ define([
             selectedProduct: function () {
                 var selected_options = {};
                 jQuery('div.swatch-attribute').each(function (k, v) {
-                    var attribute_id = jQuery(v).attr('attribute-id');
-                    var option_selected = jQuery(v).attr('option-selected');
+                    var attribute_id = jQuery(v).attr('data-attribute-id');
+                    var option_selected = jQuery(v).attr('data-option-selected');
                     if (!attribute_id || !option_selected) {
                         return;
                     }

--- a/view/frontend/web/js/swatch-renderer-mixin.js
+++ b/view/frontend/web/js/swatch-renderer-mixin.js
@@ -36,10 +36,18 @@ define([
             selectedProduct: function () {
                 var selected_options = {};
                 jQuery('div.swatch-attribute').each(function (k, v) {
+                    // In Magento 2.4+ the div attributes are called "data-attribute-id" and "data-option-selected"
+                    // In versions before 2.4, they're "attribute-id" and "option-selected". So check both.
                     var attribute_id = jQuery(v).attr('data-attribute-id');
                     var option_selected = jQuery(v).attr('data-option-selected');
                     if (!attribute_id || !option_selected) {
-                        return;
+                        // Try this if they're using version < 2.4
+                        attribute_id = jQuery(v).attr('attribute-id');
+                        option_selected = jQuery(v).attr('option-selected');
+                        // If we still don't have anything, now we can return
+                        if (!attribute_id || !option_selected) {
+                            return;
+                        }
                     }
                     selected_options[attribute_id] = option_selected;
                 });


### PR DESCRIPTION
# Changes to extension for Magento 2.4.3

## [TSD-93](https://pixlee.atlassian.net/browse/TSD-93)

### Intent or Business Objective
There are several changes contained within this PR that either fix broken behavior in Magento 2.4.3, or are best practices updates.

- Compensated for a core Magento bug where it doesn't fetch custom attribute values properly that affect PLP Rating display. 
- Updated the Ajax/Media controller override to be based on most recent version of file
- Updated class `implement`ed for custom attributes that use a dropdown to select an option after previously used class was deprecated
- Removed some leftover debug logs that use a deprecated logging method
- Updated div ID used when updates SKU when user selects a variant

### Technical Description

#### - Compensated for a core Magento bug where it doesn't fetch custom attribute values properly that affect PLP Rating display. 

In `Plugin/Review/Block/Product/ReviewRenderer.php`, instead of using `$subject->getProduct()->getTurnToRating()`, I had to explicitly fetch the product for the current storeId, and get the value using that store-scoped product.

Unfortunately I can't find the link to the core magento bug I'd found previously. Will update if I do.

- Updated the Ajax/Media controller override to be based on most recent version of file

The Ajax/Media controller was updated in Magento 2.4.3. Since we override it, our override file needed to be updated to reflect the latest code

- Updated class `implement`ed for custom attributes that use a dropdown to select an option after previously used class was deprecated

When creating custom attributes, our classes `implement`ed `\Magento\Framework\Option\ArrayInterface`. However, that class is deprecated in favor of `\Magento\Framework\Data\OptionSourceInterface`

- Removed some leftover debug logs that use a deprecated logging method

Accidentally left in some debug lines that used Zend logger, which has been removed from Magento 2

- Updated div ID used when updates SKU when user selects a variant

In previous versions of Magento, when a user selected a variant, the product id data was stored in a div attribute called `attribute-id`. In Magento 2.4, that attribute was updated to be `data-attribute-id`

---

### Questions

#### Does this PR depend on any other changes?

- [ ] This pull request depends on other changes

##### If yes for above, Include links to the additional PR(s) below:

n/a

#### Have test cases been created?
- [ ] Test cases have been created

---

### Lessons learned? Questions for reviewers?
Best to keep ahead of Magento updates.

---

### Checklist When Creating PR

- [X] Tested locally - either manually via UI or via tests
- [ ] Tests - if this is a bug fix, make sure a test is added to catch the bug going forward
- [ ] Linting/Styling changes
- [ ] Appropriate logging added to feature
- [ ] Appropriate monitoring added to feature
- [ ] Remove debug logging / redundant code / copy+paste stuff
- [ ] Squash and merge the changes to prod after approval
- [ ] Futher details on [reviewers](https://pixlee-wiki.atlassian.net/wiki/spaces/PD/pages/790003746/Pull+Requests)
- [ ] Further details on [things to do before/after pushing to production](https://pixlee-wiki.atlassian.net/wiki/spaces/PD/pages/792264797/Engineering+Production+Release+Checklist)