### PR TITLE
set a couple default values for avg rating feed, fix an indent, change default on aggregate data

### DIFF
--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -123,7 +123,7 @@ class InstallData implements \Magento\Framework\Setup\InstallDataInterface
             ]
         );
 
-       // use turnto's remote teaser code rather then local code for new installs
+        // use turnto's remote teaser code rather then local code for new installs
         $this->configWriter->save('turnto_socialcommerce_configuration/teaser/use_local_teaser_code', 0);
 
         $setup->endSetup();

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -384,7 +384,7 @@
                 </field>
                 <field id="import_aggregate_data" type="select" translate="label" sortOrder="20" showInStore="1" showInWebsite="1" showInDefault="1">
                     <label>Aggregate Related Review Count</label>
-                    <comment>Default is "No". If set to "No", the Review Count attribute will be populated with the number of reviews, NOT including related reviews. If set to "Yes", the Review Count attribute will be populated based on the number of review AND related reviews</comment>
+                    <comment>Default is "Yes". If set to "No", the Review Count attribute will be populated with the number of reviews, NOT including related reviews. If set to "Yes", the Review Count attribute will be populated based on the number of review AND related reviews</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="turnto_socialcommerce_configuration/general/enabled">1</field>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -68,6 +68,10 @@
                 <exclude_items_without_delivery_date>0</exclude_items_without_delivery_date>
                 <exclude_delivery_date_until_all_items_shipped>0</exclude_delivery_date_until_all_items_shipped>
             </historical_orders_feed>
+            <average_rating_import>
+                <enable_average_rating>1</enable_average_rating>
+                <import_aggregate_data>1</import_aggregate_data>
+            </average_rating_import>
             <sso>
                 <review_msg>We need to know who you are before we post your review. Please login or register to continue.</review_msg>
                 <review_msg_pur_req>To ensure authenticity you may only write reviews for items you've purchased. Please login or register so we can look up your purchases.</review_msg_pur_req>


### PR DESCRIPTION
# Add default value for Avg Rating Feed setting

## [TSD-103](https://pixlee.atlassian.net/browse/TSD-103)

### Intent or Business Objective
Depending on how a client installs/upgrades the extension, they can end up in a weird state where the Average Rating Feed Import is neither enabled nor disabled. Setting a default value should help resolve that

### Technical Description
Set the default value in the config.xml file.
Also fix an indent, and set the default value for Aggregate Ratings setting to Yes

---

### Questions

#### Does this PR depend on any other changes?

- [ ] This pull request depends on other changes

##### If yes for above, Include links to the additional PR(s) below:

n/a

#### Have test cases been created?
- [ ] Test cases have been created

---

### Lessons learned? Questions for reviewers?
When adding a new attribute or setting, test fresh install/upgrade scenarios

---

### Checklist When Creating PR

- [X] Tested locally - either manually via UI or via tests
- [ ] Tests - if this is a bug fix, make sure a test is added to catch the bug going forward
- [ ] Linting/Styling changes
- [ ] Appropriate logging added to feature
- [ ] Appropriate monitoring added to feature
- [ ] Remove debug logging / redundant code / copy+paste stuff
- [ ] Squash and merge the changes to prod after approval
- [ ] Futher details on [reviewers](https://pixlee-wiki.atlassian.net/wiki/spaces/PD/pages/790003746/Pull+Requests)
- [ ] Further details on [things to do before/after pushing to production](https://pixlee-wiki.atlassian.net/wiki/spaces/PD/pages/792264797/Engineering+Production+Release+Checklist)