### PR TITLE
TSD-387: Brand attribute is Returning a Number; 

### DIFF
--- a/Model/Config/Gtin.php
+++ b/Model/Config/Gtin.php
@@ -62,7 +62,7 @@ class Gtin
                 self::PRODUCT_ATTRIBUTE_MAPPINGS . $mappingKey,
                 $scopeCode
             );
-            if (!empty($tempResult)) {
+            if (!empty($value)) {
                 $gtinMap[$mappingKey] = $value;
             }
         }

--- a/Model/Export/Catalog.php
+++ b/Model/Export/Catalog.php
@@ -18,12 +18,16 @@ use Magento\Catalog\Model\Product\Visibility;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Framework\App\Area;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Intl\DateTimeFactory;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Framework\UrlInterface;
 use Magento\Eav\Model\Config as EavConfig;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Store\Model\App\Emulation;
 use SimpleXMLElement;
 use TurnTo\SocialCommerce\Api\FeedClient;
 use TurnTo\SocialCommerce\Model\Config;
@@ -89,6 +93,14 @@ class Catalog
      * @var EavConfig
      */
     protected $eavConfig;
+    /**
+     * @var Emulation
+     */
+    protected $emulation;
+    /**
+     * @var PriceCurrencyInterface
+     */
+    protected $priceCurrency;
 
     /**
      * Catalog constructor.
@@ -102,6 +114,8 @@ class Catalog
      * @param Product $product
      * @param EavConfig $eavConfig
      * @param FeedClient $feedClient
+     * @param Emulation $emulation
+     * @param PriceCurrencyInterface $priceCurrency
      * @param Monolog $logger
      */
     public function __construct(
@@ -114,6 +128,8 @@ class Catalog
         Product               $product,
         EavConfig             $eavConfig,
         FeedClient            $feedClient,
+        Emulation             $emulation,
+        PriceCurrencyInterface $priceCurrency,
         Monolog               $logger
     ) {
         $this->config = $config;
@@ -126,6 +142,8 @@ class Catalog
         $this->logger = $logger;
         $this->productCollectionFactory = $productCollectionFactory;
         $this->dateTimeFactory = $dateTimeFactory;
+        $this->emulation = $emulation;
+        $this->priceCurrency = $priceCurrency;
     }
 
     /**
@@ -137,7 +155,10 @@ class Catalog
      */
     protected function sanitizeData($dirtyString)
     {
-        return htmlspecialchars($dirtyString, ENT_XML1 | ENT_COMPAT | ENT_SUBSTITUTE, 'UTF-8');
+        if (is_string($dirtyString)) {
+            return htmlspecialchars($dirtyString, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        }
+        return $dirtyString;
     }
 
 	/**
@@ -161,7 +182,7 @@ class Catalog
                 if (is_array($label)) {
                     return implode(', ', $label);
                 }
-                return $label;
+                return (string)$label;
             }
         } catch (Exception $e) {
             $this->logger->error(
@@ -188,20 +209,17 @@ class Catalog
      */
     public function getGtinValue($product, $gtinMap)
     {
-        if (isset($gtinMap[Gtin::UPC_ATTRIBUTE])) {
-             return $this->getProductAttributeValue($product, $gtinMap[Gtin::UPC_ATTRIBUTE]);
-        }
-        if (isset($gtinMap[Gtin::ISBN_ATTRIBUTE])) {
-            return$this->getProductAttributeValue($product, $gtinMap[Gtin::ISBN_ATTRIBUTE]);
-        }
-        if (isset($gtinMap[Gtin::EAN_ATTRIBUTE])) {
-            return$this->getProductAttributeValue($product, $gtinMap[Gtin::EAN_ATTRIBUTE]);
-        }
-        if (isset($gtinMap[Gtin::JAN_ATTRIBUTE])) {
-            return$this->getProductAttributeValue($product, $gtinMap[Gtin::JAN_ATTRIBUTE]);
-        }
-        if (isset($gtinMap[Gtin::ASIN_ATTRIBUTE])) {
-            return$this->getProductAttributeValue($product, $gtinMap[Gtin::ASIN_ATTRIBUTE]);
+        $gtinAttributes = [
+            Gtin::UPC_ATTRIBUTE,
+            Gtin::EAN_ATTRIBUTE,
+            Gtin::JAN_ATTRIBUTE,
+            Gtin::ISBN_ATTRIBUTE,
+            Gtin::ASIN_ATTRIBUTE
+        ];
+        foreach ($gtinAttributes as $key) {
+            if (isset($gtinMap[$key])) {
+                return $this->getProductAttributeValue($product, $gtinMap[$key]);
+            }
         }
 
         return null;
@@ -209,35 +227,25 @@ class Catalog
 
     /**
      * @param $product
-     * @param $storeId
      * @return string
      */
-    public function getProductImageUrl($product, $storeId)
+    public function getProductImageUrl($product)
     {
         $productImageUrl = '';
         try {
-            // In order for the product image url to use the url from the proper store view, temporarily change the store
-            $currentStore = $this->storeManager->getStore();
-            $this->storeManager->setCurrentStore($storeId);
-            // Don't return placeholder image if product does not have an image
             $productImage = $product->getImage();
             if ($productImage) {
                 $productImageUrl = $this->imageHelper->init($product, 'product_page_main_image')
                     ->setImageFile($productImage)->getUrl();
-                $productImageUrl = str_replace(" ", "-", $productImageUrl);
             }
         } catch (Exception $e) {
             $this->logger->error(
-                'Error retrieving product image url',
+                'Error retrieving product image',
                 [
                     'exception' => $e,
-                    'productId' => $product->getId(),
-                    'storeId' => $storeId
+                    'productId' => $product->getId()
                 ]
             );
-        }
-        if (isset($currentStore)) {
-            $this->storeManager->setCurrentStore($currentStore);
         }
 
         return $productImageUrl;
@@ -256,9 +264,10 @@ class Catalog
         $feed = null;
         $progressCounter = 0;
         $products = [];
+        $storeId = $store->getId();
 
         try {
-            if (!$products = $this->getProducts($store, $page)) {
+            if (!$products = $this->getProducts($storeId, $page)) {
                 return false;
             }
             $feed = new SimpleXMLElement(
@@ -288,7 +297,7 @@ class Catalog
             // development time, this simpler approach is being taken and if it proves to not scale well, can be
             // refactored in the future to use a query that loads all child products for all configurable products
             // at one time.
-            if ($this->config->getUseChildSku($store->getId())) {
+            if ($this->config->getUseChildSku($storeId)) {
                 foreach ($products as $product) {
                     if ($product->getTypeId() !== Configurable::TYPE_CODE) {
                         continue;
@@ -303,11 +312,11 @@ class Catalog
 
             foreach ($products as $product) {
                 $parent = false;
-                if ($this->config->getUseChildSku($store->getId()) && isset($childProducts[$product->getSku()])) {
+                if ($this->config->getUseChildSku($storeId) && isset($childProducts[$product->getSku()])) {
                     $parent = $childProducts[$product->getSku()];
                 }
                 try {
-                    $this->addProductToAtomFeed($feed->addChild('entry'), $product, $store, $parent);
+                    $this->addProductToAtomFeed($feed->addChild('entry'), $product, $storeId, $parent);
                 } catch (Exception $entryException) {
                     $this->logger->error(
                         'Product failed to be added to feed',
@@ -361,12 +370,12 @@ class Catalog
      *
      * @param SimpleXMLElement $entry
      * @param CatalogProduct $product
-     * @param $store
-     * @param $parent bool|CatalogProduct
+     * @param int|string $storeId
+     * @param bool|CatalogProduct $parent
      *
      * @throws Exception
      */
-    protected function addProductToAtomFeed($entry, $product, $store, $parent)
+    protected function addProductToAtomFeed($entry, $product, $storeId, $parent)
     {
         if (empty($product)) {
             throw new Exception('Product can not be null or empty');
@@ -391,7 +400,7 @@ class Catalog
         $entry->addChild('id', $this->sanitizeData($sku));
 
         $identifierExists = 'FALSE';
-        $gtinMap = $this->gtinConfig->getGtinAttributesMap($store->getCode());
+        $gtinMap = $this->gtinConfig->getGtinAttributesMap($storeId);
         if (!empty($gtinMap)) {
             $gtinValue = $this->getGtinValue($product, $gtinMap);
             if (!empty($gtinValue)) {
@@ -411,7 +420,7 @@ class Catalog
                     $entry->addChild('g:mpn', $this->sanitizeData($mpn));
                 }
             }
-            if (!empty($brand) && (!empty($gtin) || !empty($mpn))) {
+            if (!empty($brand) && (!empty($gtinValue) || !empty($mpn))) {
                 $identifierExists = 'TRUE';
             }
         }
@@ -420,7 +429,7 @@ class Catalog
         $entry->addChild('g:link', $this->sanitizeData($productUrl));
         $entry->addChild('g:title', $this->sanitizeData($productName));
 
-        $categoryName = $this->getCategoryTreeString($product);
+        $categoryName = $this->getCategoryTreeString($product, $storeId);
         if (!empty($categoryName)) {
             $cleanCategoryName = $this->sanitizeData($categoryName);
             $entry->addChild('g:google_product_category', $cleanCategoryName);
@@ -435,26 +444,28 @@ class Catalog
             (($product->getStatus() == Status::STATUS_ENABLED) ? 'in stock' : 'out of stock');
 
         $entry->addChild('g:availability', $availability);
-        $productImageUrl = $this->getProductImageUrl($product, $store->getId());
+        $productImageUrl = $this->getProductImageUrl($product);
         $entry->addChild('g:image_link', $this->sanitizeData($productImageUrl));
         $entry->addChild('g:condition', 'new');
-        $price = number_format($product->getPrice(), 2, '.', '');
-        $entry->addChild('g:price', $price . ' ' . $store->getBaseCurrencyCode());
+        $price = $this->priceCurrency->convertAndRound($product->getFinalPrice(), $storeId);
+        $currencyCode = $this->priceCurrency->getCurrency($storeId)->getCurrencyCode();
+        $entry->addChild('g:price', $price . ' ' . $currencyCode);
         $itemGroupId = $this->getItemGroupId($product, $parent);
-        $entry->addChild('g:item_group_id', $itemGroupId);
+        $entry->addChild('g:item_group_id', $this->sanitizeData($itemGroupId));
     }
 
     /**
      * Gets the deepest tree for given product and returns as "rootNodeName > branchNodeName > leafNodeName"
      *
      * @param CatalogProduct $product
-     *
+     * @param int|StoreInterface|string $storeId
      * @return string
+     * @throws LocalizedException
      */
-    protected function getCategoryTreeString(CatalogProduct $product)
+    protected function getCategoryTreeString(CatalogProduct $product, $storeId)
     {
         $categoryName = '';
-        $categories = $product->getCategoryCollection();
+        $categories = $product->getCategoryCollection()->setStoreId($storeId)->addAttributeToSelect('name');
         $deepestLength = 0;
         $deepestTree = [];
 
@@ -512,24 +523,38 @@ class Catalog
     public function cronUploadFeed()
     {
         foreach ($this->storeManager->getStores() as $store) {
+            $storeId = $store->getId();
             if (
-                $this->config->getIsEnabled($store->getCode()) &&
-                $this->config->getConfigValue(Config::PRODUCT_ENABLE_AUTOMATIC_SUBMISSION, $store->getCode())
+                $this->config->getIsEnabled($storeId) &&
+                $this->config->getConfigValue(Config::PRODUCT_ENABLE_AUTOMATIC_SUBMISSION, $storeId)
             ) {
-                $page = 1;
-                while ($feed = $this->generateProductFeed($store, $page)) {
-                    try {
-                        $fileName = sprintf('%s_of_%s_store_%s_%s', $page, $this->totalPages, $store->getId(), self::FEED_STYLE);
-                        $this->feedClient->transmitFeedFile($feed, $fileName, self::FEED_STYLE, $store->getCode());
-                    } catch (Exception $e) {
-                        $this->logger->error(
-                            "TurnTo catalog export error sending page $page.",
-                            [
-                                'exception' => $e
-                            ]
-                        );
+                try {
+                    $page = 1;
+                    $this->emulation->startEnvironmentEmulation($storeId, Area::AREA_FRONTEND, true);
+                    while ($feed = $this->generateProductFeed($store, $page)) {
+                        try {
+                            $fileName = sprintf('%s_of_%s_store_%s_%s', $page, $this->totalPages, $storeId, self::FEED_STYLE);
+                            $this->feedClient->transmitFeedFile($feed, $fileName, self::FEED_STYLE, $store->getCode());
+                        } catch (Exception $e) {
+                            $this->logger->error(
+                                "TurnTo catalog export error sending page $page.",
+                                [
+                                    'exception' => $e
+                                ]
+                            );
+                        }
+                        $page++;
                     }
-                    $page++;
+                } catch (Exception $e) {
+                    $this->logger->error(
+                        'Catalog export error',
+                        [
+                            'exception' => $e,
+                            'storeId' => $storeId,
+                        ]
+                    );
+                } finally {
+                    $this->emulation->stopEnvironmentEmulation();
                 }
             }
         }
@@ -556,14 +581,15 @@ class Catalog
      * Retrieves a store/visibility filtered product collection selecting only attributes necessary for the TurnTo Feed
      * overwritten to allow for pagination
      *
-     * @param StoreInterface $store
+     * @param int|string $storeId
      * @param int $page
      * @param ?int $pageCount
      * @return Collection|false
      */
-    public function getProducts(StoreInterface $store, $page, $pageCount = 10000)
+    public function getProducts($storeId, $page, $pageCount = 10000)
     {
         $collection = $this->productCollectionFactory->create()
+            ->setStoreId($storeId)
             ->addAttributeToSelect('id')
             ->addAttributeToSelect('name')
             ->addAttributeToSelect('sku')
@@ -578,7 +604,7 @@ class Catalog
             ->addUrlRewrite()
             ->setPage($page, $pageCount);
 
-        $gtinMap = $this->gtinConfig->getGtinAttributesMap($store->getCode());
+        $gtinMap = $this->gtinConfig->getGtinAttributesMap($storeId);
 
         if (!empty($gtinMap)) {
             foreach ($gtinMap as $attributeName) {
@@ -586,7 +612,7 @@ class Catalog
             }
         }
 
-        if (!$this->config->getUseChildSku($store->getId())) {
+        if (!$this->config->getUseChildSku($storeId)) {
             $collection->addFieldToFilter(
                 'visibility',
                 [
@@ -598,7 +624,7 @@ class Catalog
             );
         }
 
-        $collection->addStoreFilter($store);
+        $collection->addStoreFilter($storeId);
 
         //used to generate file name 1_of_$totalPages.xml
         $this->totalPages = $collection->getLastPageNumber();

--- a/Model/Export/Catalog.php
+++ b/Model/Export/Catalog.php
@@ -9,9 +9,11 @@ namespace TurnTo\SocialCommerce\Model\Export;
 
 use DateTimeZone;
 use Exception;
+use Magento\Catalog\Api\Data\ProductAttributeInterface;
 use Magento\Catalog\Helper\Image;
 use Magento\Catalog\Model\Category;
 use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Catalog\Model\Product\Visibility;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
@@ -19,6 +21,7 @@ use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Intl\DateTimeFactory;
 use Magento\Framework\UrlInterface;
+use Magento\Eav\Model\Config as EavConfig;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use SimpleXMLElement;
@@ -81,37 +84,44 @@ class Catalog
     /**
      * @var Gtin
      */
-    protected $gtin;
+    protected $gtinConfig;
+    /**
+     * @var EavConfig
+     */
+    protected $eavConfig;
 
     /**
      * Catalog constructor.
      *
      * @param Config $config
-     * @param Gtin $gtin
+     * @param Gtin $gtinConfig
      * @param StoreManagerInterface $storeManager
      * @param CollectionFactory $productCollectionFactory
      * @param DateTimeFactory $dateTimeFactory
      * @param Image $imageHelper
      * @param Product $product
+     * @param EavConfig $eavConfig
      * @param FeedClient $feedClient
      * @param Monolog $logger
      */
     public function __construct(
         Config                $config,
-        Gtin                  $gtin,
+        Gtin                  $gtinConfig,
         StoreManagerInterface $storeManager,
         CollectionFactory     $productCollectionFactory,
         DateTimeFactory       $dateTimeFactory,
         Image                 $imageHelper,
         Product               $product,
+        EavConfig             $eavConfig,
         FeedClient            $feedClient,
         Monolog               $logger
     ) {
         $this->config = $config;
-        $this->gtin = $gtin;
+        $this->gtinConfig = $gtinConfig;
         $this->imageHelper = $imageHelper;
         $this->storeManager = $storeManager;
         $this->product = $product;
+        $this->eavConfig = $eavConfig;
         $this->feedClient = $feedClient;
         $this->logger = $logger;
         $this->productCollectionFactory = $productCollectionFactory;
@@ -127,15 +137,110 @@ class Catalog
      */
     protected function sanitizeData($dirtyString)
     {
-        $replacementMap = [
-            '&' => '&amp;',
-            '"' => '&quot;',
-            '\'' => '&apos;',
-            '<' => '&lt;',
-            '>' => '&gt;',
-        ];
+        return htmlspecialchars($dirtyString, ENT_XML1 | ENT_COMPAT | ENT_SUBSTITUTE, 'UTF-8');
+    }
 
-        return str_replace(array_keys($replacementMap), array_values($replacementMap), $dirtyString);
+	/**
+	 * Resolves a product attribute value, returning the display label for
+	 * EAV select/multiselect attributes instead of the raw option ID.
+	 *
+	 * @param CatalogProduct $product
+	 * @param string $attributeCode
+	 * @return string|null
+	 */
+    protected function getProductAttributeValue(CatalogProduct $product, string $attributeCode)
+    {
+        if (empty($attributeCode)) {
+            return null;
+        }
+
+        try {
+            $attribute = $this->eavConfig->getAttribute(ProductAttributeInterface::ENTITY_TYPE_CODE, $attributeCode);
+            if ($attribute && $attribute->usesSource()) {
+                $label = $product->getAttributeText($attributeCode);
+                if (is_array($label)) {
+                    return implode(', ', $label);
+                }
+                return $label;
+            }
+        } catch (Exception $e) {
+            $this->logger->error(
+                'Error retrieving product attribute',
+                [
+                    'exception' => $e,
+                    'attributeCode' => $attributeCode,
+                    'productId' => $product->getId()
+                ]
+            );
+        }
+
+        $value = $product->getData($attributeCode);
+        if (is_array($value)) {
+            return implode(', ', array_map('strval', $value));
+        }
+        return !empty($value) ? (string)$value : null;
+    }
+
+    /**
+     * @param $product
+     * @param $gtinMap
+     * @return string|null
+     */
+    public function getGtinValue($product, $gtinMap)
+    {
+        if (isset($gtinMap[Gtin::UPC_ATTRIBUTE])) {
+             return $this->getProductAttributeValue($product, $gtinMap[Gtin::UPC_ATTRIBUTE]);
+        }
+        if (isset($gtinMap[Gtin::ISBN_ATTRIBUTE])) {
+            return$this->getProductAttributeValue($product, $gtinMap[Gtin::ISBN_ATTRIBUTE]);
+        }
+        if (isset($gtinMap[Gtin::EAN_ATTRIBUTE])) {
+            return$this->getProductAttributeValue($product, $gtinMap[Gtin::EAN_ATTRIBUTE]);
+        }
+        if (isset($gtinMap[Gtin::JAN_ATTRIBUTE])) {
+            return$this->getProductAttributeValue($product, $gtinMap[Gtin::JAN_ATTRIBUTE]);
+        }
+        if (isset($gtinMap[Gtin::ASIN_ATTRIBUTE])) {
+            return$this->getProductAttributeValue($product, $gtinMap[Gtin::ASIN_ATTRIBUTE]);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param $product
+     * @param $storeId
+     * @return string
+     */
+    public function getProductImageUrl($product, $storeId)
+    {
+        $productImageUrl = '';
+        try {
+            // In order for the product image url to use the url from the proper store view, temporarily change the store
+            $currentStore = $this->storeManager->getStore();
+            $this->storeManager->setCurrentStore($storeId);
+            // Don't return placeholder image if product does not have an image
+            $productImage = $product->getImage();
+            if ($productImage) {
+                $productImageUrl = $this->imageHelper->init($product, 'product_page_main_image')
+                    ->setImageFile($productImage)->getUrl();
+                $productImageUrl = str_replace(" ", "-", $productImageUrl);
+            }
+        } catch (Exception $e) {
+            $this->logger->error(
+                'Error retrieving product image url',
+                [
+                    'exception' => $e,
+                    'productId' => $product->getId(),
+                    'storeId' => $storeId
+                ]
+            );
+        }
+        if (isset($currentStore)) {
+            $this->storeManager->setCurrentStore($currentStore);
+        }
+
+        return $productImageUrl;
     }
 
     /**
@@ -276,8 +381,6 @@ class Catalog
         if (empty($productUrl)) {
             throw new Exception('Product must have a valid store-product url');
         }
-        // Replace spaces with dashes, so we always have a valid URL
-        $productUrl = str_replace(" ", "-", $productUrl);
 
         $productName = $product->getName();
         if (empty($productName)) {
@@ -287,44 +390,26 @@ class Catalog
 
         $entry->addChild('id', $this->sanitizeData($sku));
 
-        $gtin = null;
-        $mpn = null;
-        $brand = null;
         $identifierExists = 'FALSE';
-        $gtinMap = $this->gtin->getGtinAttributesMap($store->getCode());
-
+        $gtinMap = $this->gtinConfig->getGtinAttributesMap($store->getCode());
         if (!empty($gtinMap)) {
-            if (isset($gtinMap[Gtin::MPN_ATTRIBUTE])) {
-                $mpn = $product->getData($gtinMap[Gtin::MPN_ATTRIBUTE]);
+            $gtinValue = $this->getGtinValue($product, $gtinMap);
+            if (!empty($gtinValue)) {
+                $entry->addChild('g:gtin', $this->sanitizeData($gtinValue));
             }
+            $brand = null;
             if (isset($gtinMap[Gtin::BRAND_ATTRIBUTE])) {
-                $brand = $product->getData($gtinMap[Gtin::BRAND_ATTRIBUTE]);
-            }
-            if (empty($gtin)) {
-                if (isset($gtinMap[Gtin::UPC_ATTRIBUTE])) {
-                    $gtin = $product->getData($gtinMap[Gtin::UPC_ATTRIBUTE]);
-                }
-                if (isset($gtinMap[Gtin::ISBN_ATTRIBUTE])) {
-                    $gtin = $product->getData($gtinMap[Gtin::ISBN_ATTRIBUTE]);
-                }
-                if (isset($gtinMap[Gtin::EAN_ATTRIBUTE])) {
-                    $gtin = $product->getData($gtinMap[Gtin::EAN_ATTRIBUTE]);
-                }
-                if (isset($gtinMap[Gtin::JAN_ATTRIBUTE])) {
-                    $gtin = $product->getData($gtinMap[Gtin::JAN_ATTRIBUTE]);
-                }
-                if (isset($gtinMap[Gtin::ASIN_ATTRIBUTE])) {
-                    $gtin = $product->getData($gtinMap[Gtin::ASIN_ATTRIBUTE]);
+                $brand = $this->getProductAttributeValue($product, $gtinMap[Gtin::BRAND_ATTRIBUTE]);
+                if (!empty($brand)) {
+                    $entry->addChild('g:brand', $this->sanitizeData($brand));
                 }
             }
-            if (!empty($gtin)) {
-                $entry->addChild('g:gtin', $this->sanitizeData($gtin));
-            }
-            if (!empty($brand)) {
-                $entry->addChild('g:brand', $this->sanitizeData($brand));
-            }
-            if (!empty($mpn)) {
-                $entry->addChild('g:mpn', $this->sanitizeData($mpn));
+            $mpn = null;
+            if (isset($gtinMap[Gtin::MPN_ATTRIBUTE])) {
+                $mpn = $this->getProductAttributeValue($product, $gtinMap[Gtin::MPN_ATTRIBUTE]);
+                if (!empty($mpn)) {
+                    $entry->addChild('g:mpn', $this->sanitizeData($mpn));
+                }
             }
             if (!empty($brand) && (!empty($gtin) || !empty($mpn))) {
                 $identifierExists = 'TRUE';
@@ -332,7 +417,7 @@ class Catalog
         }
 
         $entry->addChild('g:identifier_exists', $identifierExists);
-        $entry->addChild('g:link', $productUrl);
+        $entry->addChild('g:link', $this->sanitizeData($productUrl));
         $entry->addChild('g:title', $this->sanitizeData($productName));
 
         $categoryName = $this->getCategoryTreeString($product);
@@ -342,36 +427,19 @@ class Catalog
             $entry->addChild('g:product_type', $cleanCategoryName);
         }
 
-        // In order for the product image url to use the url from the proper store view, temporarily change the store
-        $currentStore = $this->storeManager->getStore();
-        $this->storeManager->setCurrentStore($store->getStoreId());
-
-        // Check if the product has an image. If it does NOT, we don't send an image URL, so TurnTo doesn't
-        // just process the placeholder image
-        $productHasImage = (bool) $product->getData('image');
-        if (!$productHasImage) {
-            $productImageUrl = '';
-        } else {
-            $productImageUrl = $this->imageHelper->init($product, 'product_page_main_image')->setImageFile(
-                $product->getImage()
-            )->getUrl();
-            $productImageUrl = str_replace(" ", "-", $productImageUrl);
-        }
-
-        // Restore the "current store"
-        $this->storeManager->setCurrentStore($currentStore);
-
         // Availability is normally determined by status, but can be overridden by custom "turnto_disabled" attribute
         $turntoDisable = $product->getCustomAttribute('turnto_disabled') ?
             $product->getCustomAttribute('turnto_disabled')->getValue() :
             false;
         $availability = $turntoDisable ? 'out of stock' :
-            (($product->getStatus() == 1) ? 'in stock' : 'out of stock');
+            (($product->getStatus() == Status::STATUS_ENABLED) ? 'in stock' : 'out of stock');
 
         $entry->addChild('g:availability', $availability);
+        $productImageUrl = $this->getProductImageUrl($product, $store->getId());
         $entry->addChild('g:image_link', $this->sanitizeData($productImageUrl));
         $entry->addChild('g:condition', 'new');
-        $entry->addChild('g:price', $product->getPrice() . ' ' . $store->getBaseCurrencyCode());
+        $price = number_format($product->getPrice(), 2, '.', '');
+        $entry->addChild('g:price', $price . ' ' . $store->getBaseCurrencyCode());
         $itemGroupId = $this->getItemGroupId($product, $parent);
         $entry->addChild('g:item_group_id', $itemGroupId);
     }
@@ -510,7 +578,7 @@ class Catalog
             ->addUrlRewrite()
             ->setPage($page, $pageCount);
 
-        $gtinMap = $this->gtin->getGtinAttributesMap($store->getCode());
+        $gtinMap = $this->gtinConfig->getGtinAttributesMap($store->getCode());
 
         if (!empty($gtinMap)) {
             foreach ($gtinMap as $attributeName) {

--- a/Test/Unit/Model/Export/CatalogTest.php
+++ b/Test/Unit/Model/Export/CatalogTest.php
@@ -8,17 +8,26 @@ declare(strict_types=1);
 namespace TurnTo\SocialCommerce\Test\Unit\Model\Export;
 
 use Magento\Catalog\Helper\Image;
+use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Directory\Model\Currency;
 use Magento\Framework\Intl\DateTimeFactory;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Store\Model\App\Emulation;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Eav\Model\Config as EavConfig;
+use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
+use SimpleXMLElement;
 use TurnTo\SocialCommerce\Api\FeedClient;
 use TurnTo\SocialCommerce\Model\Config as ConfigModel;
 use TurnTo\SocialCommerce\Model\Config\Gtin;
 use TurnTo\SocialCommerce\Model\Product;
 use TurnTo\SocialCommerce\Logger\Monolog;
 use TurnTo\SocialCommerce\Model\Export\Catalog;
+use TurnTo\SocialCommerce\Test\Unit\Model\Export\TestableCatalog;
 
 class CatalogTest extends TestCase
 {
@@ -28,25 +37,191 @@ class CatalogTest extends TestCase
     protected $catalog;
 
     /**
+     * @var EavConfig
+     */
+    protected $eavConfig;
+
+    /**
      * Is called before running a test
      * @throws Exception
      */
     protected function setUp(): void
     {
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $dateTimeFactory = $this->createMock(DateTimeFactory::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $this->eavConfig = $this->createMock(EavConfig::class);
+        $feedClient = $this->createMock(FeedClient::class);
+        $emulation = $this->createMock(Emulation::class);
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $logger = $this->createMock(Monolog::class);
+
         $this->catalog = new Catalog(
-            $this->createMock(ConfigModel::class),
-            $this->createMock(Gtin::class),
-            $this->createMock(StoreManagerInterface::class),
-            $this->createMock(CollectionFactory::class),
-            $this->createMock(DateTimeFactory::class),
-            $this->createMock(Image::class),
-            $this->createMock(Product::class),
-            $this->createMock(FeedClient::class),
-            $this->createMock(Monolog::class)
+            $config,
+            $gtin,
+            $storeManager,
+            $collectionFactory,
+            $dateTimeFactory,
+            $imageHelper,
+            $turntoProduct,
+            $this->eavConfig,
+            $feedClient,
+            $emulation,
+            $priceCurrency,
+            $logger
         );
     }
 
     public function testIsCatalogClass(){
         $this->assertInstanceOf(Catalog::class, $this->catalog);
+    }
+
+    public function testGetGtinValueReturnsLabelForSelectAttribute()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $attribute = $this->getMockBuilder(AbstractAttribute::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['usesSource'])
+            ->getMock();
+        $attribute->method('usesSource')->willReturn(true);
+        $this->eavConfig->method('getAttribute')->willReturn($attribute);
+
+        $product->method('getAttributeText')
+            ->with('upc')
+            ->willReturn('UPC Label');
+
+        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
+        $this->assertSame('UPC Label', $this->catalog->getGtinValue($product, $gtinMap));
+    }
+
+    public function testGetGtinValueReturnsCommaSeparatedForMultiselect()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $attribute = $this->getMockBuilder(AbstractAttribute::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['usesSource'])
+            ->getMock();
+        $attribute->method('usesSource')->willReturn(true);
+        $this->eavConfig->method('getAttribute')->willReturn($attribute);
+
+        $product->method('getAttributeText')
+            ->with('upc')
+            ->willReturn(['Red', 'Blue']);
+
+        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
+        $this->assertSame('Red, Blue', $this->catalog->getGtinValue($product, $gtinMap));
+    }
+
+    public function testGetGtinValueReturnsRawForNonSourceAttribute()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $attribute = $this->getMockBuilder(AbstractAttribute::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['usesSource'])
+            ->getMock();
+        $attribute->method('usesSource')->willReturn(false);
+        $this->eavConfig->method('getAttribute')->willReturn($attribute);
+
+        $product->method('getData')
+            ->with('upc')
+            ->willReturn('12345');
+
+        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
+        $this->assertSame('12345', $this->catalog->getGtinValue($product, $gtinMap));
+    }
+
+    public function testGetGtinValueReturnsImplodedForArrayData()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $attribute = $this->getMockBuilder(AbstractAttribute::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['usesSource'])
+            ->getMock();
+        $attribute->method('usesSource')->willReturn(false);
+        $this->eavConfig->method('getAttribute')->willReturn($attribute);
+
+        $product->method('getData')
+            ->with('upc')
+            ->willReturn([1, 2]);
+
+        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
+        $this->assertSame('1, 2', $this->catalog->getGtinValue($product, $gtinMap));
+    }
+
+    public function testAddProductToAtomFeedWritesConvertedFinalPriceWithCurrency()
+    {
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $dateTimeFactory = $this->createMock(DateTimeFactory::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $feedClient = $this->createMock(FeedClient::class);
+        $emulation = $this->createMock(Emulation::class);
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $logger = $this->createMock(Monolog::class);
+
+        // Ensure safe SKU encoding passthrough
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return (string) $value;
+        });
+
+        // Set expectations for currency conversion and currency code retrieval
+        $storeId = 1;
+        $finalPrice = 12.34;
+
+        $priceCurrency
+            ->expects($this->once())
+            ->method('convertAndRound')
+            ->with($finalPrice, $storeId)
+            ->willReturn($finalPrice);
+
+        $currencyMock = $this->createPartialMock(
+            Currency::class,
+            ['getCurrencyCode']
+        );
+        $currencyMock->method('getCurrencyCode')->willReturn('USD');
+        $priceCurrency->method('getCurrency')->with($storeId)->willReturn($currencyMock);
+
+        // Build the catalog instance under test
+        $catalog = new TestableCatalog(
+            $config,
+            $gtin,
+            $storeManager,
+            $collectionFactory,
+            $dateTimeFactory,
+            $imageHelper,
+            $turntoProduct,
+            $this->eavConfig,
+            $feedClient,
+            $emulation,
+            $priceCurrency,
+            $logger
+        );
+
+        // Minimal product stub to satisfy feed requirements
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('SKU-1');
+        $product->method('getProductUrl')->willReturn('https://example.com/p');
+        $product->method('getName')->willReturn('Product Name');
+        $product->method('getImage')->willReturn(null); // avoid image helper chain
+        $product->method('getFinalPrice')->willReturn($finalPrice);
+        $product->method('getCustomAttribute')->willReturn(null);
+        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+
+        $entry = new SimpleXMLElement('<entry />');
+
+        // Execute
+        $catalog->callAddProductToAtomFeed($entry, $product, $storeId, false);
+
+        // Assert price element is present and formatted with currency code
+        $xmlString = $entry->asXML();
+        $this->assertIsString($xmlString);
+        $this->assertStringContainsString('<price>12.34 USD</price>', $xmlString);
     }
 }

--- a/Test/Unit/Model/Export/TestableCatalog.php
+++ b/Test/Unit/Model/Export/TestableCatalog.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Test\Unit\Model\Export;
+
+use Magento\Catalog\Model\Product as CatalogProduct;
+use TurnTo\SocialCommerce\Model\Export\Catalog;
+
+/**
+ * Testable subclass to expose protected methods and stub category tree logic
+ */
+class TestableCatalog extends Catalog
+{
+    public function callAddProductToAtomFeed($entry, $product, $storeId, $parent)
+    {
+        $this->addProductToAtomFeed($entry, $product, $storeId, $parent);
+    }
+
+    // Avoids needing a real category collection in unit test
+    protected function getCategoryTreeString(CatalogProduct $product, $storeId)
+    {
+        return '';
+    }
+}
+
+

--- a/view/adminhtml/templates/system/config/exportCatalog.phtml
+++ b/view/adminhtml/templates/system/config/exportCatalog.phtml
@@ -1,13 +1,7 @@
 <?php
 /**
- * TurnTo_SocialCommerce
- * NOTICE OF LICENSE
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
- * @copyright  Copyright (c) 2018 TurnTo Networks, Inc.
- * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
  */
 ?>
 <?php /* @var $block \TurnTo\SocialCommerce\Block\System\Config\ExportCatalog */ ?>
@@ -16,30 +10,43 @@
     require([
         'jquery',
         'prototype'
-    ], function(jQuery){
-
-        var exportCatalogSpan = jQuery('#export_catalog_span');
-
-        jQuery('#export_catalog_button').click(function () {
+    ], function($){
+        $('#export_catalog_button').click(function () {
+            const exportCatalogSpan = $('#export_catalog_span');
+            const exportCatalogSuccess = exportCatalogSpan.find('.collected');
+            const exportCatalogProcessing = exportCatalogSpan.find('.processing');
+            const exportMessageSpan = $('#export_message_span');
             new Ajax.Request('<?php echo $block->getAjaxUrl() ?>', {
-                loaderArea:     false,
-                asynchronous:   true,
+                loaderArea: false,
+                asynchronous: true,
                 onCreate: function() {
-                    exportCatalogSpan.find('.collected').hide();
-                    exportCatalogSpan.find('.processing').show();
-                    jQuery('#export_message_span').text('');
+                    exportCatalogSuccess.hide();
+                    exportCatalogProcessing.show();
+                    exportMessageSpan.text('');
                 },
                 onSuccess: function(response) {
-                    exportCatalogSpan.find('.processing').hide();
-
-                    var resultText = '';
+                    exportCatalogProcessing.hide();
+                    let resultText = '';
                     if (response.status > 200) {
-                        resultText = response.statusText;
+                        resultText = response.statusText || 'Error';
                     } else {
                         resultText = 'Success';
-                        exportCatalogSpan.find('.collected').show();
+                        exportCatalogSuccess.show();
                     }
-                    jQuery('#export_message_span').text(resultText);
+                    exportMessageSpan.text(resultText);
+                },
+                onFailure: function(response) {
+                    exportCatalogProcessing.hide();
+                    exportMessageSpan.text('Request failed');
+                    console.error(response && response.statusText ? response.statusText : 'Request failed');
+                },
+                onException: function(_, e) {
+                    exportCatalogProcessing.hide();
+                    exportMessageSpan.text('Error');
+                    console.error(e && e.message ? e.message : 'Unknown error');
+                },
+                onComplete: function() {
+                    exportCatalogProcessing.hide();
                 }
             });
         });


### PR DESCRIPTION
- Use emulation to emulate the specific store and set the store for collections and price for each file
  - This ensures all product data used is specific to the store and not the default
- Updated to use store ID where possible to simplify things
  - In many places methods allow either store, store ID, or store code
- Created new methods for getting attribute values, gtin values, and product image url and cleaned up this logic
  - Get attribute text if available rather than using getData which returns the integer for select/multi-select attributes
  - Fix Gtin var
  - Use htmlspecialchars for improved xml sanitizing 
- Updated tests