### PR TITLE
TSD-415: Implement Commerce Catalog Feed

### DIFF
--- a/Api/FeedGeneratorInterface.php
+++ b/Api/FeedGeneratorInterface.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace TurnTo\SocialCommerce\Api;
 
+use LogicException;
 use Magento\Store\Api\Data\StoreInterface;
 
 interface FeedGeneratorInterface
@@ -33,8 +34,16 @@ interface FeedGeneratorInterface
      * Finish the feed generation and return the feed data.
      *
      * @return mixed string
+     * @throws LogicException If the feed has not been initialized via beginFeed().
      */
     public function finishFeed();
+
+    /**
+     * Check whether the feed stream is currently open and accepting new products.
+     *
+     * @return bool
+     */
+    public function isFeedOpen(): bool;
 
     /**
      * Get the feed style identifier.

--- a/Api/FeedGeneratorInterface.php
+++ b/Api/FeedGeneratorInterface.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Api;
+
+use Magento\Store\Api\Data\StoreInterface;
+
+interface FeedGeneratorInterface
+{
+    /**
+     * Start the feed generation process.
+     *
+     * @param StoreInterface $store
+     * @return void
+     */
+    public function beginFeed(StoreInterface $store);
+
+    /**
+     * Add a product to the feed.
+     *
+     * @param mixed $product
+     * @param mixed $parent
+     * @param int|string|null $storeId
+     * @return void
+     */
+    public function addProduct($product, $parent = null, $storeId = null);
+
+    /**
+     * Finish the feed generation and return the feed data.
+     *
+     * @return mixed string
+     */
+    public function finishFeed();
+
+    /**
+     * Get the feed style identifier.
+     *
+     * @return string
+     */
+    public function getFeedStyle(): string;
+}

--- a/Api/FeedGeneratorInterface.php
+++ b/Api/FeedGeneratorInterface.php
@@ -25,9 +25,9 @@ interface FeedGeneratorInterface
      * @param mixed $product
      * @param mixed $parent
      * @param int|string|null $storeId
-     * @return void
+     * @return bool True when line/item was added to the feed, false otherwise.
      */
-    public function addProduct($product, $parent = null, $storeId = null);
+    public function addProduct($product, $parent = null, $storeId = null): bool;
 
     /**
      * Finish the feed generation and return the feed data.

--- a/Block/TurnToConfig.php
+++ b/Block/TurnToConfig.php
@@ -15,6 +15,7 @@ use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use TurnTo\SocialCommerce\Api\TurnToConfigDataSourceInterface;
 use TurnTo\SocialCommerce\Model\Config as ConfigModel;
+use TurnTo\SocialCommerce\Model\Product;
 use TurnTo\SocialCommerce\Model\Version;
 
 class TurnToConfig extends Template
@@ -39,6 +40,10 @@ class TurnToConfig extends Template
      * @var Json
      */
     protected $json;
+    /**
+     * @var Product
+     */
+    protected $productModel;
 
     /**
      * @param Context $context
@@ -46,6 +51,7 @@ class TurnToConfig extends Template
      * @param ResolverInterface $localeResolver
      * @param Data $helper
      * @param Version $version
+     * @param Product $productModel
      * @param Json $json
      * @param array $data
      */
@@ -55,6 +61,7 @@ class TurnToConfig extends Template
         ResolverInterface $localeResolver,
         Data $helper,
         Version $version,
+        Product $productModel,
         Json $json,
         array $data = []
     ) {
@@ -68,6 +75,7 @@ class TurnToConfig extends Template
         $this->localeResolver = $localeResolver;
         $this->helper = $helper;
         $this->version = $version;
+        $this->productModel = $productModel;
         $this->json = $json;
     }
 
@@ -101,7 +109,7 @@ class TurnToConfig extends Template
         if ($this->config->getConfigBool(ConfigModel::VISUAL_CONTENT_ENABLE_GALLERY_ROW)) {
             $product = $this->helper->getProduct();
             if ($product) {
-                $skus = [$product->getSku()];
+                $skus = [$this->productModel->turnToSafeEncoding($product->getSku())];
                 $additionalConfigData['gallery'] = ['skus' => $skus];
             }
         }

--- a/Block/Widget/Pinboard.php
+++ b/Block/Widget/Pinboard.php
@@ -20,6 +20,7 @@ use Magento\Rule\Model\Condition\Sql\Builder;
 use Magento\Widget\Helper\Conditions;
 use TurnTo\SocialCommerce\Block\TurnToConfig;
 use TurnTo\SocialCommerce\Model\Config;
+use TurnTo\SocialCommerce\Model\Product;
 use TurnTo\SocialCommerce\Model\Data\PinboardConfigFactory;
 
 class Pinboard extends ProductsList
@@ -32,6 +33,10 @@ class Pinboard extends ProductsList
      * @var PinboardConfigFactory
      */
     protected $pinboardConfigFactory;
+    /**
+     * @var Product
+     */
+    protected $product;
 
     /**
      * @param Config $config
@@ -49,6 +54,7 @@ class Pinboard extends ProductsList
     public function __construct(
         Config $config,
         PinboardConfigFactory $pinboardConfigFactory,
+        Product $product,
         Context $context,
         CollectionFactory $productCollectionFactory,
         Visibility $catalogProductVisibility,
@@ -61,6 +67,7 @@ class Pinboard extends ProductsList
     ) {
         $this->config = $config;
         $this->pinboardConfigFactory = $pinboardConfigFactory;
+        $this->product = $product;
         parent::__construct(
             $context,
             $productCollectionFactory,
@@ -114,7 +121,11 @@ class Pinboard extends ProductsList
     public function getProductSkus()
     {
         $productSkus = $this->getData('skus');
-        return $productSkus ? array_map('trim' , explode(',', $productSkus)) : [];
+        if (!$productSkus) {
+            return [];
+        }
+
+        return array_map([$this->product, 'turnToSafeEncoding'], array_map('trim', explode(',', $productSkus)));
     }
 
     /**

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -41,6 +41,7 @@ class Config
     public const CHECKOUT_CUSTOMER_NAME_FALLBACK = 'turnto_socialcommerce_configuration/checkout_comments/js_order_feed_customer_name_fallback';
 
     public const PRODUCT_ENABLE_AUTOMATIC_SUBMISSION = 'turnto_socialcommerce_configuration/product_feed/enable_automatic_submission';
+    public const PRODUCT_FEED_FORMAT = 'turnto_socialcommerce_configuration/product_feed/feed_format';
     public const PRODUCT_FEED_URL = 'turnto_socialcommerce_configuration/product_feed/product_feed_url';
     public const PRODUCT_FEED_SUBMISSION_URL = 'turnto_socialcommerce_configuration/product_feed/feed_submission_url';
     public const PRODUCT_REVIEW_URL = 'turnto_socialcommerce_configuration/product_feed/review_api_url';
@@ -180,5 +181,15 @@ class Config
     public function getUseChildSku($scopeCode = null, $scopeType = ScopeInterface::SCOPE_STORES)
     {
         return $this->getConfigBool(self::GENERAL_USE_CHILD_SKU, $scopeCode, $scopeType);
+    }
+
+    /**
+     * @param string|int|null $scopeCode
+     * @param string $scopeType
+     * @return string|null
+     */
+    public function getFeedFormat($scopeCode = null, $scopeType = ScopeInterface::SCOPE_STORES)
+    {
+        return $this->getConfigValue(self::PRODUCT_FEED_FORMAT, $scopeCode, $scopeType);
     }
 }

--- a/Model/Config/Source/FeedFormat.php
+++ b/Model/Config/Source/FeedFormat.php
@@ -20,8 +20,8 @@ class FeedFormat implements OptionSourceInterface
     public function toOptionArray()
     {
         return [
-            ['value' => self::COMMERCE, 'label' => __('Commerce Product Catalog Feed')],
-            ['value' => self::GOOGLE_PRODUCT, 'label' => __('Google Product XML (Deprecated)')]
+            ['value' => self::GOOGLE_PRODUCT, 'label' => __('Google Products Atom 1.0')],
+            ['value' => self::COMMERCE, 'label' => __('Commerce Product Catalog Feed')]
         ];
     }
 }

--- a/Model/Config/Source/FeedFormat.php
+++ b/Model/Config/Source/FeedFormat.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class FeedFormat implements OptionSourceInterface
+{
+    public const GOOGLE_PRODUCT = 'google-product.xml';
+    public const COMMERCE = 'tab-style.commerce';
+
+    /**
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return [
+            ['value' => self::COMMERCE, 'label' => __('Commerce Product Catalog Feed')],
+            ['value' => self::GOOGLE_PRODUCT, 'label' => __('Google Product XML (Deprecated)')]
+        ];
+    }
+}

--- a/Model/Export/Catalog.php
+++ b/Model/Export/Catalog.php
@@ -188,7 +188,19 @@ class Catalog
                                 $feedData = $generator->finishFeed();
                                 $totalFiles = ceil($this->totalPages / $pagesPerBatch);
                                 $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);
-                                $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
+
+                                try {
+                                    $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
+                                } catch (Exception $e) {
+                                    $this->logger->error(
+                                        "TurnTo catalog export transmit file error",
+                                        [
+                                            'store_id' => $storeId,
+                                            'file_name' => $fileName,
+                                            'exception' => $e
+                                        ]
+                                    );
+                                }
 
                                 $productCount = 0;
                                 $fileIndex++;

--- a/Model/Export/Catalog.php
+++ b/Model/Export/Catalog.php
@@ -30,15 +30,6 @@ use TurnTo\SocialCommerce\Service\Feed\FeedGeneratorFactory;
  */
 class Catalog
 {
-    const MAX_TRANSMISSION_ATTEMPTS = 3;
-
-    /**
-     * Delay between retry attempts in microseconds.
-     *
-     * usleep() expects microseconds, so keep the suffix for clarity.
-     */
-    const TRANSMISSION_RETRY_DELAY_MICROSECONDS = 0;
-
     /**
      * @var FeedGeneratorFactory
      */
@@ -258,36 +249,12 @@ class Catalog
                                 $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);
 
                                 try {
-                                    $attempts = 0;
-                                    while (true) {
-                                        try {
-                                            $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
-                                            break;
-                                        } catch (Exception $transmitException) {
-                                            $attempts++;
-                                            if ($attempts >= self::MAX_TRANSMISSION_ATTEMPTS) {
-                                                throw $transmitException;
-                                            }
-                                            $this->logger->warning(
-                                                'TurnTo catalog export transmit file failed; retrying',
-                                                [
-                                                    'storeId' => $storeId,
-                                                    'file_name' => $fileName,
-                                                    'page' => $page,
-                                                    'batch_size' => $batchSize,
-                                                    'file_index' => $fileIndex,
-                                                    'attempt' => $attempts,
-                                                    'exception' => $transmitException
-                                                ]
-                                            );
-                                            usleep(self::TRANSMISSION_RETRY_DELAY_MICROSECONDS);
-                                        }
-                                    }
+                                    $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
                                 } catch (Exception $e) {
                                     $this->logger->error(
                                         'TurnTo catalog export transmit file error',
                                         [
-                                            'storeId' => $storeId,
+                                            'store_id' => $storeId,
                                             'file_name' => $fileName,
                                             'page' => $page,
                                             'batch_size' => $batchSize,
@@ -330,27 +297,18 @@ class Catalog
                         $feedData = $generator->finishFeed();
                         $totalFiles = ceil($this->totalPages / $pagesPerBatch);
                         $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);
-                        $attempts = 0;
-                        while (true) {
-                            try {
-                                $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
-                                break;
-                                } catch (Exception $transmitException) {
-                                $attempts++;
-                                if ($attempts >= self::MAX_TRANSMISSION_ATTEMPTS) {
-                                        throw $transmitException;
-                                }
-                                $this->logger->warning(
-                                    'TurnTo catalog export transmit file failed; retrying',
-                                    [
-                                        'storeId' => $storeId,
-                                        'file_name' => $fileName,
-                                        'attempt' => $attempts,
-                                        'exception' => $transmitException
-                                    ]
-                                );
-                                usleep(self::TRANSMISSION_RETRY_DELAY_MICROSECONDS);
-                            }
+                        try {
+                            $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
+                        } catch (Exception $e) {
+                            $this->logger->error(
+                                'TurnTo catalog export transmit file error',
+                                [
+                                    'store_id' => $storeId,
+                                    'file_name' => $fileName,
+                                    'exception' => $e
+                                ]
+                            );
+                            throw $e;
                         }
                     }
                 } catch (Exception $e) {

--- a/Model/Export/Catalog.php
+++ b/Model/Export/Catalog.php
@@ -137,6 +137,10 @@ class Catalog
                 $this->config->getConfigValue(Config::PRODUCT_ENABLE_AUTOMATIC_SUBMISSION, $storeId)
             ) {
                 $emulationStarted = false;
+                $page = 1;
+                $productCount = 0;
+                $fileIndex = 1;
+                $generator = null;
                 try {
                     $feedFormat = $this->config->getFeedFormat($storeId);
                     $siteKey = $this->config->getSiteKey($storeId);
@@ -175,10 +179,6 @@ class Catalog
                     $batchSize = 10000;
                     $pageSize = 500;
                     $pagesPerBatch = ceil($batchSize / $pageSize);
-                    $page = 1;
-                    $productCount = 0;
-                    $fileIndex = 1;
-                    $hasActiveFeed = false;
                     $products = $this->getProducts($storeId, $page, $pageSize);
                     if (!$products) {
                         continue;
@@ -256,13 +256,13 @@ class Catalog
                             $this->exportProduct->preloadRewriteUrls($storeId, $productIds);
                             $this->categoryPathResolver->preloadCategoryPaths($storeId, $categoryProductIds);
 
+                            if (!$generator->isFeedOpen()) {
+                                $generator->beginFeed($store);
+                            }
+
                             foreach ($products as $product) {
                                 $parent = isset($childProducts[(int) $product->getId()]) ? $childProducts[(int) $product->getId()] : false;
                                 if ($generator->addProduct($product, $parent, $storeId)) {
-                                    if (!$hasActiveFeed) {
-                                        $generator->beginFeed($store);
-                                        $hasActiveFeed = true;
-                                    }
                                     $productCount++;
                                 }
                             }
@@ -293,7 +293,6 @@ class Catalog
 
                                 $productCount = 0;
                                 $fileIndex++;
-                                $hasActiveFeed = false;
                             }
                         } catch (Exception $e) {
                             $this->logger->error(
@@ -301,7 +300,7 @@ class Catalog
                                 [
                                     'store_id' => $storeId,
                                     'store_code' => $store->getCode(),
-                                    'page' => $page,
+                                    'page' => $page ?? null,
                                     'exception' => $e
                                 ]
                             );
@@ -319,7 +318,7 @@ class Catalog
                         }
                     }
 
-                    if ($hasActiveFeed && $productCount > 0) {
+                    if ($generator->isFeedOpen() && $productCount > 0) {
                         $feedData = $generator->finishFeed();
                         $totalFiles = ceil($this->totalPages / $pagesPerBatch);
                         $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);
@@ -336,8 +335,25 @@ class Catalog
                             );
                             throw $e;
                         }
+                    } elseif ($generator->isFeedOpen()) {
+                        $generator->finishFeed();
                     }
                 } catch (Exception $e) {
+                    if ($generator !== null && $generator->isFeedOpen()) {
+                        try {
+                            $generator->finishFeed();
+                        } catch (Exception $finishException) {
+                            $this->logger->error(
+                                'TurnTo catalog export failed to finish feed',
+                                [
+                                    'store_id' => $storeId,
+                                    'store_code' => $store->getCode(),
+                                    'exception' => $finishException
+                                ]
+                            );
+                        }
+                    }
+
                     $this->logger->error(
                         'Catalog export error',
                         [

--- a/Model/Export/Catalog.php
+++ b/Model/Export/Catalog.php
@@ -198,31 +198,45 @@ class Catalog
                                     $connection = $this->resourceConnection->getConnection();
                                     $select = $connection->select()
                                         ->from(['l' => $connection->getTableName('catalog_product_super_link')], ['parent_id', 'product_id'])
-                                        ->join(['ce' => $connection->getTableName('catalog_product_entity')], 'ce.entity_id = l.product_id', ['child_sku' => 'sku'])
                                         ->join(['pe' => $connection->getTableName('catalog_product_entity')], 'pe.entity_id = l.parent_id', ['parent_sku' => 'sku'])
                                         ->where('l.product_id IN (?)', $simpleIds);
                                     $rows = $connection->fetchAll($select);
 
                                     if (!empty($rows)) {
-                                        $parentIdsToLoad = [];
+                                    $parentIdsToLoad = [];
                                         $parentMap = [];
                                         $emptyCollection = $this->productCollectionFactory->create();
+                                    $parentIds = array_values(array_unique(array_map('intval', array_column($rows, 'parent_id'))));
+                                    $parentCollection = $this->productCollectionFactory->create();
+                                    $parentCollection->setStoreId($storeId)
+                                        ->addAttributeToSelect(['url_key', 'url_path'])
+                                        ->addFieldToFilter('entity_id', ['in' => $parentIds]);
+                                    $loadedParentProducts = [];
+                                    foreach ($parentCollection as $parentProduct) {
+                                        $loadedParentProducts[(int) $parentProduct->getId()] = $parentProduct;
+                                    }
 
                                         foreach ($rows as $row) {
                                             $parentId = (int)$row['parent_id'];
                                             $parentIdsToLoad[] = $parentId;
 
                                             if (!isset($parentMap[$parentId])) {
+                                            if (isset($loadedParentProducts[$parentId])) {
+                                                $parentProduct = $loadedParentProducts[$parentId];
+                                            } else {
                                                 $parentProduct = $emptyCollection->getNewEmptyItem();
                                                 $parentProduct->setData([
                                                     'entity_id' => $parentId,
                                                     'sku' => $row['parent_sku'],
+                                                    'type_id' => 'configurable',
                                                     'store_id' => $storeId
                                                 ]);
+                                            }
+
                                                 $parentMap[$parentId] = $parentProduct;
                                             }
 
-                                            $childProducts[$row['child_sku']] = $parentMap[$parentId];
+                                            $childProducts[(int)$row['product_id']] = $parentMap[$parentId];
                                         }
 
                                         $productIds = array_merge($productIds, array_unique($parentIdsToLoad));
@@ -235,7 +249,7 @@ class Catalog
                             $this->exportProduct->preloadRewriteUrls($storeId, $productIds);
 
                             foreach ($products as $product) {
-                                $parent = isset($childProducts[$product->getSku()]) ? $childProducts[$product->getSku()] : false;
+                                $parent = isset($childProducts[(int) $product->getId()]) ? $childProducts[(int) $product->getId()] : false;
                                 if ($generator->addProduct($product, $parent, $storeId)) {
                                     $productCount++;
                                 }
@@ -355,18 +369,13 @@ class Catalog
             ->setOrder('entity_id', 'ASC')
             ->setPage($page, $pageCount);
 
-        $collection->joinField(
-            'qty',
-            'cataloginventory_stock_item',
-            'qty',
+        $collection->joinTable(
+            ['stock_item' => 'cataloginventory_stock_item'],
             'product_id=entity_id',
-            '{{table}}.stock_id=1',
-            'left'
-        )->joinField(
-            'is_in_stock',
-            'cataloginventory_stock_item',
-            'is_in_stock',
-            'product_id=entity_id',
+            [
+                'qty' => 'qty',
+                'is_in_stock' => 'is_in_stock'
+            ],
             '{{table}}.stock_id=1',
             'left'
         );

--- a/Model/Export/Catalog.php
+++ b/Model/Export/Catalog.php
@@ -7,60 +7,32 @@ declare(strict_types=1);
 
 namespace TurnTo\SocialCommerce\Model\Export;
 
-use DateTimeZone;
 use Exception;
-use Magento\Catalog\Api\Data\ProductAttributeInterface;
-use Magento\Catalog\Helper\Image;
-use Magento\Catalog\Model\Category;
-use Magento\Catalog\Model\Product as CatalogProduct;
-use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Catalog\Model\Product\Visibility;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Framework\App\Area;
+use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Framework\Intl\DateTimeFactory;
-use Magento\Framework\Pricing\PriceCurrencyInterface;
-use Magento\Framework\UrlInterface;
-use Magento\Eav\Model\Config as EavConfig;
-use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\App\Emulation;
-use SimpleXMLElement;
 use TurnTo\SocialCommerce\Api\FeedClient;
+use TurnTo\SocialCommerce\Logger\Monolog;
 use TurnTo\SocialCommerce\Model\Config;
 use TurnTo\SocialCommerce\Model\Config\Gtin;
-use TurnTo\SocialCommerce\Model\Product;
-use TurnTo\SocialCommerce\Logger\Monolog;
+use TurnTo\SocialCommerce\Model\Export\Product as ExportProduct;
+use TurnTo\SocialCommerce\Service\Feed\FeedGeneratorFactory;
 
 /**
- * Class Catalog
- * @package TurnTo\SocialCommerce\Model\Export
+ * Export Catalog
  */
 class Catalog
 {
     /**
-     * Feed Style used for the Product Feed
+     * @var FeedGeneratorFactory
      */
-    const FEED_STYLE = 'google-product.xml';
-
-    /**
-     * @var Image $imageHelper
-     */
-    protected $imageHelper = null;
-
-    /**
-     * @var Product
-     */
-    protected $product;
-
-    /**
-     * Used to generate file name (x_of_totalPages_feed.xml)
-     * @var Int
-     */
-    protected $totalPages;
+    protected $feedGeneratorFactory;
     /**
      * @var StoreManagerInterface
      */
@@ -82,25 +54,26 @@ class Catalog
      */
     protected $productCollectionFactory;
     /**
-     * @var DateTimeFactory
-     */
-    protected $dateTimeFactory;
-    /**
      * @var Gtin
      */
     protected $gtinConfig;
-    /**
-     * @var EavConfig
-     */
-    protected $eavConfig;
     /**
      * @var Emulation
      */
     protected $emulation;
     /**
-     * @var PriceCurrencyInterface
+     * @var ResourceConnection
      */
-    protected $priceCurrency;
+    protected $resourceConnection;
+    /**
+     * @var ExportProduct
+     */
+    protected $exportProduct;
+
+    /**
+     * @var Int
+     */
+    protected $totalPages;
 
     /**
      * Catalog constructor.
@@ -109,410 +82,35 @@ class Catalog
      * @param Gtin $gtinConfig
      * @param StoreManagerInterface $storeManager
      * @param CollectionFactory $productCollectionFactory
-     * @param DateTimeFactory $dateTimeFactory
-     * @param Image $imageHelper
-     * @param Product $product
-     * @param EavConfig $eavConfig
      * @param FeedClient $feedClient
      * @param Emulation $emulation
-     * @param PriceCurrencyInterface $priceCurrency
      * @param Monolog $logger
+     * @param FeedGeneratorFactory $feedGeneratorFactory
+     * @param ResourceConnection $resourceConnection
+     * @param ExportProduct $exportProduct
      */
     public function __construct(
         Config                $config,
         Gtin                  $gtinConfig,
         StoreManagerInterface $storeManager,
         CollectionFactory     $productCollectionFactory,
-        DateTimeFactory       $dateTimeFactory,
-        Image                 $imageHelper,
-        Product               $product,
-        EavConfig             $eavConfig,
         FeedClient            $feedClient,
         Emulation             $emulation,
-        PriceCurrencyInterface $priceCurrency,
-        Monolog               $logger
+        Monolog               $logger,
+        FeedGeneratorFactory  $feedGeneratorFactory,
+        ResourceConnection    $resourceConnection,
+        ExportProduct         $exportProduct
     ) {
         $this->config = $config;
         $this->gtinConfig = $gtinConfig;
-        $this->imageHelper = $imageHelper;
         $this->storeManager = $storeManager;
-        $this->product = $product;
-        $this->eavConfig = $eavConfig;
         $this->feedClient = $feedClient;
         $this->logger = $logger;
         $this->productCollectionFactory = $productCollectionFactory;
-        $this->dateTimeFactory = $dateTimeFactory;
         $this->emulation = $emulation;
-        $this->priceCurrency = $priceCurrency;
-    }
-
-    /**
-     * Escapes special characters for xml use
-     *
-     * @param string $dirtyString
-     *
-     * @return string
-     */
-    protected function sanitizeData($dirtyString)
-    {
-        if (is_string($dirtyString)) {
-            return htmlspecialchars($dirtyString, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
-        }
-        return $dirtyString;
-    }
-
-	/**
-	 * Resolves a product attribute value, returning the display label for
-	 * EAV select/multiselect attributes instead of the raw option ID.
-	 *
-	 * @param CatalogProduct $product
-	 * @param string $attributeCode
-	 * @return string|null
-	 */
-    protected function getProductAttributeValue(CatalogProduct $product, string $attributeCode)
-    {
-        if (empty($attributeCode)) {
-            return null;
-        }
-
-        try {
-            $attribute = $this->eavConfig->getAttribute(ProductAttributeInterface::ENTITY_TYPE_CODE, $attributeCode);
-            if ($attribute && $attribute->usesSource()) {
-                $label = $product->getAttributeText($attributeCode);
-                if (is_array($label)) {
-                    return implode(', ', $label);
-                }
-                return (string)$label;
-            }
-        } catch (Exception $e) {
-            $this->logger->error(
-                'Error retrieving product attribute',
-                [
-                    'exception' => $e,
-                    'attributeCode' => $attributeCode,
-                    'productId' => $product->getId()
-                ]
-            );
-        }
-
-        $value = $product->getData($attributeCode);
-        if (is_array($value)) {
-            return implode(', ', array_map('strval', $value));
-        }
-        return !empty($value) ? (string)$value : null;
-    }
-
-    /**
-     * @param $product
-     * @param $gtinMap
-     * @return string|null
-     */
-    public function getGtinValue($product, $gtinMap)
-    {
-        $gtinAttributes = [
-            Gtin::UPC_ATTRIBUTE,
-            Gtin::EAN_ATTRIBUTE,
-            Gtin::JAN_ATTRIBUTE,
-            Gtin::ISBN_ATTRIBUTE,
-            Gtin::ASIN_ATTRIBUTE
-        ];
-        foreach ($gtinAttributes as $key) {
-            if (isset($gtinMap[$key])) {
-                return $this->getProductAttributeValue($product, $gtinMap[$key]);
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @param $product
-     * @return string
-     */
-    public function getProductImageUrl($product)
-    {
-        $productImageUrl = '';
-        try {
-            $productImage = $product->getImage();
-            if ($productImage) {
-                $productImageUrl = $this->imageHelper->init($product, 'product_page_main_image')
-                    ->setImageFile($productImage)->getUrl();
-            }
-        } catch (Exception $e) {
-            $this->logger->error(
-                'Error retrieving product image',
-                [
-                    'exception' => $e,
-                    'productId' => $product->getId()
-                ]
-            );
-        }
-
-        return $productImageUrl;
-    }
-
-    /**
-     * Writes all individually visible products to an ATOM 1.0 feed which is returned in a SimpleXMLElement Object
-     *
-     * @param StoreInterface $store
-     * @param $page
-     * @return bool|SimpleXMLElement
-     * @throws Exception If feed could not be generated
-     */
-    protected function generateProductFeed(StoreInterface $store, $page)
-    {
-        $feed = null;
-        $progressCounter = 0;
-        $products = [];
-        $storeId = $store->getId();
-
-        try {
-            if (!$products = $this->getProducts($storeId, $page)) {
-                return false;
-            }
-            $feed = new SimpleXMLElement(
-                '<?xml version="1.0" encoding="UTF-8"?>' . '<feed xmlns="http://www.w3.org/2005/Atom"' . ' xmlns:g="http://base.google.com/ns/1.0" xml:lang="en-US" />'
-            );
-
-            $feed->addChild('title', $this->sanitizeData($store->getName() . ' - Google Product Atom 1.0 Feed'));
-            $feed->addChild(
-                'link',
-                $this->sanitizeData($store->getBaseUrl(UrlInterface::URL_TYPE_LINK))
-            );
-            $feed->addChild(
-                'updated',
-                $this->dateTimeFactory->create('now', new DateTimeZone('UTC'))->format(DATE_ATOM)
-            );
-            $feed->addChild('author')->addChild('name', 'TurnTo');
-            $feed->addChild(
-                'id',
-                $this->sanitizeData($store->getBaseUrl(UrlInterface::URL_TYPE_WEB))
-            );
-
-            $childProducts = [];
-
-            // TurnTo requires a product feed where children of configurable products are aware of their parent SKUs
-            // and include that parent SKU in the feed. This code is not very performant and therefore the feed will
-            // take longer to generate in large catalogs with many configurable products. However in the interest of
-            // development time, this simpler approach is being taken and if it proves to not scale well, can be
-            // refactored in the future to use a query that loads all child products for all configurable products
-            // at one time.
-            if ($this->config->getUseChildSku($storeId)) {
-                foreach ($products as $product) {
-                    if ($product->getTypeId() !== Configurable::TYPE_CODE) {
-                        continue;
-                    }
-
-                    $children = $product->getTypeInstance()->getUsedProducts($product);
-                    foreach ($children as $child) {
-                        $childProducts[$child->getSku()] = $product;
-                    }
-                }
-            }
-
-            foreach ($products as $product) {
-                $parent = false;
-                if ($this->config->getUseChildSku($storeId) && isset($childProducts[$product->getSku()])) {
-                    $parent = $childProducts[$product->getSku()];
-                }
-                try {
-                    $this->addProductToAtomFeed($feed->addChild('entry'), $product, $storeId, $parent);
-                } catch (Exception $entryException) {
-                    $this->logger->error(
-                        'Product failed to be added to feed',
-                        [
-                            'exception' => $entryException,
-                            'productSKU' => $product->getSku()
-                        ]
-                    );
-                }
-                $progressCounter++;
-            }
-
-            return $feed;
-        } catch (Exception $e) {
-            if ($feed) {
-                $this->logger->error(
-                    'An exception occurred while generating the catalog feed',
-                    [
-                        'exception' => $e,
-                        'productCount' => count($products),
-                        'productsProcessed' => $progressCounter
-                    ]
-                );
-                throw $e;
-            }
-            if ($products) {
-                $this->logger->error(
-                    'An exception occurred that prevented the creation of the catalog feed due to invalid product data.',
-                    [
-                        'exception' => $e,
-                        'productCount' => count($products),
-                        'productsProcessed' => $progressCounter
-                    ]
-                );
-                throw $e;
-            }
-            $this->logger->error(
-                'An exception occurred while retrieving the products for the catalog feed',
-                [
-                    'exception' => $e,
-                    'productsProcessed' => $progressCounter
-                ]
-            );
-
-            throw $e;
-        }
-    }
-
-    /**
-     * Adds a Magento catalog product to a Google Products ATOM 1.0 xml feed
-     *
-     * @param SimpleXMLElement $entry
-     * @param CatalogProduct $product
-     * @param int|string $storeId
-     * @param bool|CatalogProduct $parent
-     *
-     * @throws Exception
-     */
-    protected function addProductToAtomFeed($entry, $product, $storeId, $parent)
-    {
-        if (empty($product)) {
-            throw new Exception('Product can not be null or empty');
-        }
-
-        $sku = $this->product->turnToSafeEncoding($product->getSku());
-        if (empty($sku)) {
-            throw new Exception('Product must have a valid sku');
-        }
-
-        $productUrl = $parent ? $parent->getProductUrl() : $product->getProductUrl();
-        if (empty($productUrl)) {
-            throw new Exception('Product must have a valid store-product url');
-        }
-
-        $productName = $product->getName();
-        if (empty($productName)) {
-            throw new Exception('Product must have a valid name');
-        }
-        $productName = str_replace("\n", "", $productName);
-
-        $entry->addChild('id', $this->sanitizeData($sku));
-
-        $identifierExists = 'FALSE';
-        $gtinMap = $this->gtinConfig->getGtinAttributesMap($storeId);
-        if (!empty($gtinMap)) {
-            $gtinValue = $this->getGtinValue($product, $gtinMap);
-            if (!empty($gtinValue)) {
-                $entry->addChild('g:gtin', $this->sanitizeData($gtinValue));
-            }
-            $brand = null;
-            if (isset($gtinMap[Gtin::BRAND_ATTRIBUTE])) {
-                $brand = $this->getProductAttributeValue($product, $gtinMap[Gtin::BRAND_ATTRIBUTE]);
-                if (!empty($brand)) {
-                    $entry->addChild('g:brand', $this->sanitizeData($brand));
-                }
-            }
-            $mpn = null;
-            if (isset($gtinMap[Gtin::MPN_ATTRIBUTE])) {
-                $mpn = $this->getProductAttributeValue($product, $gtinMap[Gtin::MPN_ATTRIBUTE]);
-                if (!empty($mpn)) {
-                    $entry->addChild('g:mpn', $this->sanitizeData($mpn));
-                }
-            }
-            if (!empty($brand) && (!empty($gtinValue) || !empty($mpn))) {
-                $identifierExists = 'TRUE';
-            }
-        }
-
-        $entry->addChild('g:identifier_exists', $identifierExists);
-        $entry->addChild('g:link', $this->sanitizeData($productUrl));
-        $entry->addChild('g:title', $this->sanitizeData($productName));
-
-        $categoryName = $this->getCategoryTreeString($product, $storeId);
-        if (!empty($categoryName)) {
-            $cleanCategoryName = $this->sanitizeData($categoryName);
-            $entry->addChild('g:google_product_category', $cleanCategoryName);
-            $entry->addChild('g:product_type', $cleanCategoryName);
-        }
-
-        // Availability is normally determined by status, but can be overridden by custom "turnto_disabled" attribute
-        $turntoDisable = $product->getCustomAttribute('turnto_disabled') ?
-            $product->getCustomAttribute('turnto_disabled')->getValue() :
-            false;
-        $availability = $turntoDisable ? 'out of stock' :
-            (($product->getStatus() == Status::STATUS_ENABLED) ? 'in stock' : 'out of stock');
-
-        $entry->addChild('g:availability', $availability);
-        $productImageUrl = $this->getProductImageUrl($product);
-        $entry->addChild('g:image_link', $this->sanitizeData($productImageUrl));
-        $entry->addChild('g:condition', 'new');
-        $price = $this->priceCurrency->convertAndRound($product->getFinalPrice(), $storeId);
-        $currencyCode = $this->priceCurrency->getCurrency($storeId)->getCurrencyCode();
-        $entry->addChild('g:price', $price . ' ' . $currencyCode);
-        $itemGroupId = $this->getItemGroupId($product, $parent);
-        $entry->addChild('g:item_group_id', $this->sanitizeData($itemGroupId));
-    }
-
-    /**
-     * Gets the deepest tree for given product and returns as "rootNodeName > branchNodeName > leafNodeName"
-     *
-     * @param CatalogProduct $product
-     * @param int|StoreInterface|string $storeId
-     * @return string
-     * @throws LocalizedException
-     */
-    protected function getCategoryTreeString(CatalogProduct $product, $storeId)
-    {
-        $categoryName = '';
-        $categories = $product->getCategoryCollection()->setStoreId($storeId)->addAttributeToSelect('name');
-        $deepestLength = 0;
-        $deepestTree = [];
-
-        foreach ($categories as $category) {
-            $tempTree = $this->getCategoryBranch($category);
-            $treeLength = count($tempTree);
-            if ($treeLength > $deepestLength) {
-                $deepestLength = $treeLength;
-                $deepestTree = $tempTree;
-            }
-        }
-
-        foreach (array_reverse($deepestTree) as $node) {
-            $nodeName = $node->getName();
-            if (!empty($nodeName)) {
-                if (!empty($categoryName)) {
-                    $categoryName .= ' > ';
-                }
-                $categoryName .= $node->getName();
-            }
-        }
-
-        return $categoryName;
-    }
-
-    /**
-     * Recursively walks category chain from leaf to root while writing the traversed branch to an array
-     *
-     * @param Category $category
-     * @param array                           $categoryBranch
-     *
-     * @return array
-     */
-    protected function getCategoryBranch(Category $category, array $categoryBranch = [])
-    {
-        try {
-            $parent = $category->getParentCategory();
-        } catch (NoSuchEntityException $isRootEntity) {
-            $parent = null;
-        } finally {
-            $categoryBranch[] = $category;
-            if (isset($parent)) {
-                return $this->getCategoryBranch($parent, $categoryBranch);
-            } else {
-                return $categoryBranch;
-            }
-        }
+        $this->feedGeneratorFactory = $feedGeneratorFactory;
+        $this->resourceConnection = $resourceConnection;
+        $this->exportProduct = $exportProduct;
     }
 
     /**
@@ -531,10 +129,71 @@ class Catalog
                 try {
                     $page = 1;
                     $this->emulation->startEnvironmentEmulation($storeId, Area::AREA_FRONTEND, true);
-                    while ($feed = $this->generateProductFeed($store, $page)) {
+                    $feedFormat = $this->config->getFeedFormat($storeId);
+                    $generator = $this->feedGeneratorFactory->create($feedFormat);
+                    $feedStyle = $generator->getFeedStyle();
+
+                    $batchSize = 10000;
+                    $pageSize = 500;
+                    $pagesPerBatch = ceil($batchSize / $pageSize);
+                    $productCount = 0;
+                    $fileIndex = 1;
+
+                    $generator->beginFeed($store);
+
+                    while ($products = $this->getProducts($storeId, $page, $pageSize)) {
                         try {
-                            $fileName = sprintf('%s_of_%s_store_%s_%s', $page, $this->totalPages, $storeId, self::FEED_STYLE);
-                            $this->feedClient->transmitFeedFile($feed, $fileName, self::FEED_STYLE, $store->getCode());
+                            $productIds = [];
+                            foreach ($products as $product) {
+                                $productIds[] = $product->getId();
+                            }
+                            $this->exportProduct->preloadRewriteUrls($storeId, $productIds);
+
+                            $childProducts = [];
+                            if ($this->config->getUseChildSku($storeId)) {
+                                $configurableIds = [];
+                                $parentMap = [];
+                                foreach ($products as $product) {
+                                    if ($product->getTypeId() === Configurable::TYPE_CODE) {
+                                        $configurableIds[] = $product->getId();
+                                        $parentMap[$product->getId()] = $product;
+                                    }
+                                }
+
+                                if (!empty($configurableIds)) {
+                                    $connection = $this->resourceConnection->getConnection();
+                                    $select = $connection->select()
+                                        ->from(['l' => $connection->getTableName('catalog_product_super_link')], ['parent_id', 'product_id'])
+                                        ->join(['e' => $connection->getTableName('catalog_product_entity')], 'e.entity_id = l.product_id', ['sku'])
+                                        ->where('l.parent_id IN (?)', $configurableIds);
+                                    $rows = $connection->fetchAll($select);
+
+                                    foreach ($rows as $row) {
+                                        $childProducts[$row['sku']] = $parentMap[$row['parent_id']];
+                                    }
+                                }
+                            }
+
+                            foreach ($products as $product) {
+                                $parent = isset($childProducts[$product->getSku()]) ? $childProducts[$product->getSku()] : false;
+                                $generator->addProduct($product, $parent, $storeId);
+                                $productCount++;
+                            }
+
+                            $products->clear();
+                            unset($products);
+                            gc_collect_cycles();
+
+                            if ($productCount >= $batchSize) {
+                                $feedData = $generator->finishFeed();
+                                $totalFiles = ceil($this->totalPages / $pagesPerBatch);
+                                $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);
+                                $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
+
+                                $productCount = 0;
+                                $fileIndex++;
+                                $generator->beginFeed($store);
+                            }
                         } catch (Exception $e) {
                             $this->logger->error(
                                 "TurnTo catalog export error sending page $page.",
@@ -544,6 +203,13 @@ class Catalog
                             );
                         }
                         $page++;
+                    }
+
+                    if ($productCount > 0) {
+                        $feedData = $generator->finishFeed();
+                        $totalFiles = ceil($this->totalPages / $pagesPerBatch);
+                        $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);
+                        $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
                     }
                 } catch (Exception $e) {
                     $this->logger->error(
@@ -561,23 +227,6 @@ class Catalog
     }
 
     /**
-     * Get item group ID for a given product
-     *
-     * @param CatalogProduct $product
-     * @param CatalogProduct|bool $parent
-     *
-     * @return string
-     */
-    public function getItemGroupId($product, $parent)
-    {
-        if ($parent) {
-            return $parent->getSku();
-        } else {
-            return $product->getSku();
-        }
-    }
-
-    /**
      * Retrieves a store/visibility filtered product collection selecting only attributes necessary for the TurnTo Feed
      * overwritten to allow for pagination
      *
@@ -585,24 +234,37 @@ class Catalog
      * @param int $page
      * @param ?int $pageCount
      * @return Collection|false
+     * @throws LocalizedException
      */
-    public function getProducts($storeId, $page, $pageCount = 10000)
+    public function getProducts($storeId, $page, $pageCount = 500)
     {
         $collection = $this->productCollectionFactory->create()
             ->setStoreId($storeId)
-            ->addAttributeToSelect('id')
+            ->addAttributeToSelect('url_key')
             ->addAttributeToSelect('name')
             ->addAttributeToSelect('sku')
-            ->addAttributeToSelect('url_path')
-            ->addAttributeToSelect('url_key')
-            ->addAttributeToSelect('url_in_store')
             ->addAttributeToSelect('image')
-            ->addAttributeToSelect('quantity_and_stock_status')
             ->addAttributeToSelect('price')
             ->addAttributeToSelect('status')
             ->addAttributeToSelect('turnto_disabled')
             ->addUrlRewrite()
             ->setPage($page, $pageCount);
+
+        $collection->joinField(
+            'qty',
+            'cataloginventory_stock_item',
+            'qty',
+            'product_id=entity_id',
+            '{{table}}.stock_id=1',
+            'left'
+        )->joinField(
+            'is_in_stock',
+            'cataloginventory_stock_item',
+            'is_in_stock',
+            'product_id=entity_id',
+            '{{table}}.stock_id=1',
+            'left'
+        );
 
         $gtinMap = $this->gtinConfig->getGtinAttributesMap($storeId);
 

--- a/Model/Export/Catalog.php
+++ b/Model/Export/Catalog.php
@@ -21,6 +21,7 @@ use TurnTo\SocialCommerce\Api\FeedClient;
 use TurnTo\SocialCommerce\Logger\Monolog;
 use TurnTo\SocialCommerce\Model\Config;
 use TurnTo\SocialCommerce\Model\Config\Gtin;
+use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
 use TurnTo\SocialCommerce\Model\Export\Product as ExportProduct;
 use TurnTo\SocialCommerce\Service\Feed\FeedGeneratorFactory;
 
@@ -29,6 +30,15 @@ use TurnTo\SocialCommerce\Service\Feed\FeedGeneratorFactory;
  */
 class Catalog
 {
+    const MAX_TRANSMISSION_ATTEMPTS = 3;
+
+    /**
+     * Delay between retry attempts in microseconds.
+     *
+     * usleep() expects microseconds, so keep the suffix for clarity.
+     */
+    const TRANSMISSION_RETRY_DELAY_MICROSECONDS = 0;
+
     /**
      * @var FeedGeneratorFactory
      */
@@ -126,80 +136,166 @@ class Catalog
                 $this->config->getIsEnabled($storeId) &&
                 $this->config->getConfigValue(Config::PRODUCT_ENABLE_AUTOMATIC_SUBMISSION, $storeId)
             ) {
+                $emulationStarted = false;
                 try {
-                    $page = 1;
-                    $this->emulation->startEnvironmentEmulation($storeId, Area::AREA_FRONTEND, true);
                     $feedFormat = $this->config->getFeedFormat($storeId);
+                    $siteKey = $this->config->getSiteKey($storeId);
+                    $authorizationKey = $this->config->getAuthorizationKey($storeId);
+                    $submissionUrl = $this->config->getConfigValue(Config::PRODUCT_FEED_SUBMISSION_URL, $storeId);
+
+                    if (!in_array($feedFormat, [FeedFormat::GOOGLE_PRODUCT, FeedFormat::COMMERCE], true)) {
+                        $this->logger->error(
+                            'TurnTo catalog export skipped due to unsupported feed format',
+                            [
+                                'store_id' => $storeId,
+                                'feed_format' => $feedFormat
+                            ]
+                        );
+                        continue;
+                    }
+
+                    if (empty($siteKey) || empty($authorizationKey) || empty($submissionUrl)) {
+                        $this->logger->error(
+                            'TurnTo catalog export skipped due to incomplete TurnTo credentials',
+                            [
+                                'store_id' => $storeId,
+                                'site_key_set' => !empty($siteKey),
+                                'auth_key_set' => !empty($authorizationKey),
+                                'submission_url_set' => !empty($submissionUrl)
+                            ]
+                        );
+                        continue;
+                    }
+
+                    $this->emulation->startEnvironmentEmulation($storeId, Area::AREA_FRONTEND, true);
+                    $emulationStarted = true;
                     $generator = $this->feedGeneratorFactory->create($feedFormat);
                     $feedStyle = $generator->getFeedStyle();
 
                     $batchSize = 10000;
                     $pageSize = 500;
                     $pagesPerBatch = ceil($batchSize / $pageSize);
+                    $page = 1;
                     $productCount = 0;
                     $fileIndex = 1;
+                    $products = $this->getProducts($storeId, $page, $pageSize);
+                    if (!$products) {
+                        continue;
+                    }
+                    $totalPages = $this->totalPages;
+                    $totalFiles = $totalPages > 0 ? ceil($totalPages / $pagesPerBatch) : 0;
 
                     $generator->beginFeed($store);
 
-                    while ($products = $this->getProducts($storeId, $page, $pageSize)) {
+                    while (true) {
                         try {
                             $productIds = [];
                             foreach ($products as $product) {
                                 $productIds[] = $product->getId();
                             }
-                            $this->exportProduct->preloadRewriteUrls($storeId, $productIds);
 
                             $childProducts = [];
                             if ($this->config->getUseChildSku($storeId)) {
-                                $configurableIds = [];
-                                $parentMap = [];
+                                $simpleIds = [];
                                 foreach ($products as $product) {
-                                    if ($product->getTypeId() === Configurable::TYPE_CODE) {
-                                        $configurableIds[] = $product->getId();
-                                        $parentMap[$product->getId()] = $product;
+                                    if ($product->getTypeId() !== Configurable::TYPE_CODE) {
+                                        $simpleIds[] = $product->getId();
                                     }
                                 }
 
-                                if (!empty($configurableIds)) {
+                                if (!empty($simpleIds)) {
                                     $connection = $this->resourceConnection->getConnection();
                                     $select = $connection->select()
                                         ->from(['l' => $connection->getTableName('catalog_product_super_link')], ['parent_id', 'product_id'])
-                                        ->join(['e' => $connection->getTableName('catalog_product_entity')], 'e.entity_id = l.product_id', ['sku'])
-                                        ->where('l.parent_id IN (?)', $configurableIds);
+                                        ->join(['ce' => $connection->getTableName('catalog_product_entity')], 'ce.entity_id = l.product_id', ['child_sku' => 'sku'])
+                                        ->join(['pe' => $connection->getTableName('catalog_product_entity')], 'pe.entity_id = l.parent_id', ['parent_sku' => 'sku'])
+                                        ->where('l.product_id IN (?)', $simpleIds);
                                     $rows = $connection->fetchAll($select);
 
-                                    foreach ($rows as $row) {
-                                        $childProducts[$row['sku']] = $parentMap[$row['parent_id']];
+                                    if (!empty($rows)) {
+                                        $parentIdsToLoad = [];
+                                        $parentMap = [];
+                                        $emptyCollection = $this->productCollectionFactory->create();
+
+                                        foreach ($rows as $row) {
+                                            $parentId = (int)$row['parent_id'];
+                                            $parentIdsToLoad[] = $parentId;
+
+                                            if (!isset($parentMap[$parentId])) {
+                                                $parentProduct = $emptyCollection->getNewEmptyItem();
+                                                $parentProduct->setData([
+                                                    'entity_id' => $parentId,
+                                                    'sku' => $row['parent_sku'],
+                                                    'store_id' => $storeId
+                                                ]);
+                                                $parentMap[$parentId] = $parentProduct;
+                                            }
+
+                                            $childProducts[$row['child_sku']] = $parentMap[$parentId];
+                                        }
+
+                                        $productIds = array_merge($productIds, array_unique($parentIdsToLoad));
+
+                                        unset($emptyCollection, $parentMap);
                                     }
                                 }
                             }
 
+                            $this->exportProduct->preloadRewriteUrls($storeId, $productIds);
+
                             foreach ($products as $product) {
                                 $parent = isset($childProducts[$product->getSku()]) ? $childProducts[$product->getSku()] : false;
-                                $generator->addProduct($product, $parent, $storeId);
-                                $productCount++;
+                                if ($generator->addProduct($product, $parent, $storeId)) {
+                                    $productCount++;
+                                }
                             }
 
                             $products->clear();
                             unset($products);
-                            gc_collect_cycles();
 
                             if ($productCount >= $batchSize) {
                                 $feedData = $generator->finishFeed();
-                                $totalFiles = ceil($this->totalPages / $pagesPerBatch);
                                 $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);
 
                                 try {
-                                    $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
+                                    $attempts = 0;
+                                    while (true) {
+                                        try {
+                                            $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
+                                            break;
+                                        } catch (Exception $transmitException) {
+                                            $attempts++;
+                                            if ($attempts >= self::MAX_TRANSMISSION_ATTEMPTS) {
+                                                throw $transmitException;
+                                            }
+                                            $this->logger->warning(
+                                                'TurnTo catalog export transmit file failed; retrying',
+                                                [
+                                                    'storeId' => $storeId,
+                                                    'file_name' => $fileName,
+                                                    'page' => $page,
+                                                    'batch_size' => $batchSize,
+                                                    'file_index' => $fileIndex,
+                                                    'attempt' => $attempts,
+                                                    'exception' => $transmitException
+                                                ]
+                                            );
+                                            usleep(self::TRANSMISSION_RETRY_DELAY_MICROSECONDS);
+                                        }
+                                    }
                                 } catch (Exception $e) {
                                     $this->logger->error(
-                                        "TurnTo catalog export transmit file error",
+                                        'TurnTo catalog export transmit file error',
                                         [
-                                            'store_id' => $storeId,
+                                            'storeId' => $storeId,
                                             'file_name' => $fileName,
+                                            'page' => $page,
+                                            'batch_size' => $batchSize,
+                                            'file_index' => $fileIndex,
                                             'exception' => $e
                                         ]
                                     );
+                                    throw $e;
                                 }
 
                                 $productCount = 0;
@@ -208,31 +304,68 @@ class Catalog
                             }
                         } catch (Exception $e) {
                             $this->logger->error(
-                                "TurnTo catalog export error sending page $page.",
+                                'TurnTo catalog export error sending page',
                                 [
+                                    'store_id' => $storeId,
+                                    'store_code' => $store->getCode(),
+                                    'page' => $page,
                                     'exception' => $e
                                 ]
                             );
+                            throw $e;
                         }
+
+                        if ($page >= $totalPages) {
+                            break;
+                        }
+
                         $page++;
+                        $products = $this->getProducts($storeId, $page, $pageSize, false);
+                        if (!$products) {
+                            break;
+                        }
                     }
 
                     if ($productCount > 0) {
                         $feedData = $generator->finishFeed();
                         $totalFiles = ceil($this->totalPages / $pagesPerBatch);
                         $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);
-                        $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
+                        $attempts = 0;
+                        while (true) {
+                            try {
+                                $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
+                                break;
+                                } catch (Exception $transmitException) {
+                                $attempts++;
+                                if ($attempts >= self::MAX_TRANSMISSION_ATTEMPTS) {
+                                        throw $transmitException;
+                                }
+                                $this->logger->warning(
+                                    'TurnTo catalog export transmit file failed; retrying',
+                                    [
+                                        'storeId' => $storeId,
+                                        'file_name' => $fileName,
+                                        'attempt' => $attempts,
+                                        'exception' => $transmitException
+                                    ]
+                                );
+                                usleep(self::TRANSMISSION_RETRY_DELAY_MICROSECONDS);
+                            }
+                        }
                     }
                 } catch (Exception $e) {
                     $this->logger->error(
                         'Catalog export error',
                         [
                             'exception' => $e,
-                            'storeId' => $storeId,
+                            'store_id' => $storeId,
+                            'store_code' => $store->getCode(),
                         ]
                     );
                 } finally {
-                    $this->emulation->stopEnvironmentEmulation();
+                    if ($emulationStarted) {
+                        $this->emulation->stopEnvironmentEmulation();
+                    }
                 }
             }
         }
@@ -245,10 +378,11 @@ class Catalog
      * @param int|string $storeId
      * @param int $page
      * @param ?int $pageCount
+     * @param bool $fetchTotalPages
      * @return Collection|false
      * @throws LocalizedException
      */
-    public function getProducts($storeId, $page, $pageCount = 500)
+    public function getProducts($storeId, $page, $pageCount = 500, $fetchTotalPages = true)
     {
         $collection = $this->productCollectionFactory->create()
             ->setStoreId($storeId)
@@ -260,6 +394,7 @@ class Catalog
             ->addAttributeToSelect('status')
             ->addAttributeToSelect('turnto_disabled')
             ->addUrlRewrite()
+            ->setOrder('entity_id', 'ASC')
             ->setPage($page, $pageCount);
 
         $collection->joinField(
@@ -300,12 +435,17 @@ class Catalog
 
         $collection->addStoreFilter($storeId);
 
-        //used to generate file name 1_of_$totalPages.xml
-        $this->totalPages = $collection->getLastPageNumber();
-
-        //stop the feed once we get to the last page
-        if ($this->totalPages < $page) {
+        if (!$fetchTotalPages && $this->totalPages > 0 && $page > $this->totalPages) {
             return false;
+        }
+
+        if ($fetchTotalPages) {
+            //used to generate file name 1_of_$totalPages.xml
+            $this->totalPages = $collection->getLastPageNumber();
+            //stop the feed once we get to the last page
+            if ($this->totalPages < $page) {
+                return false;
+            }
         }
 
         return $collection;

--- a/Model/Export/Catalog.php
+++ b/Model/Export/Catalog.php
@@ -22,6 +22,7 @@ use TurnTo\SocialCommerce\Logger\Monolog;
 use TurnTo\SocialCommerce\Model\Config;
 use TurnTo\SocialCommerce\Model\Config\Gtin;
 use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
+use TurnTo\SocialCommerce\Model\Export\CategoryPathResolver;
 use TurnTo\SocialCommerce\Model\Export\Product as ExportProduct;
 use TurnTo\SocialCommerce\Service\Feed\FeedGeneratorFactory;
 
@@ -72,6 +73,11 @@ class Catalog
     protected $exportProduct;
 
     /**
+     * @var CategoryPathResolver
+     */
+    protected $categoryPathResolver;
+
+    /**
      * @var Int
      */
     protected $totalPages;
@@ -89,6 +95,7 @@ class Catalog
      * @param FeedGeneratorFactory $feedGeneratorFactory
      * @param ResourceConnection $resourceConnection
      * @param ExportProduct $exportProduct
+     * @param CategoryPathResolver $categoryPathResolver
      */
     public function __construct(
         Config                $config,
@@ -100,7 +107,8 @@ class Catalog
         Monolog               $logger,
         FeedGeneratorFactory  $feedGeneratorFactory,
         ResourceConnection    $resourceConnection,
-        ExportProduct         $exportProduct
+        ExportProduct         $exportProduct,
+        CategoryPathResolver  $categoryPathResolver
     ) {
         $this->config = $config;
         $this->gtinConfig = $gtinConfig;
@@ -112,6 +120,7 @@ class Catalog
         $this->feedGeneratorFactory = $feedGeneratorFactory;
         $this->resourceConnection = $resourceConnection;
         $this->exportProduct = $exportProduct;
+        $this->categoryPathResolver = $categoryPathResolver;
     }
 
     /**
@@ -169,14 +178,13 @@ class Catalog
                     $page = 1;
                     $productCount = 0;
                     $fileIndex = 1;
+                    $hasActiveFeed = false;
                     $products = $this->getProducts($storeId, $page, $pageSize);
                     if (!$products) {
                         continue;
                     }
                     $totalPages = $this->totalPages;
                     $totalFiles = $totalPages > 0 ? ceil($totalPages / $pagesPerBatch) : 0;
-
-                    $generator->beginFeed($store);
 
                     while (true) {
                         try {
@@ -244,11 +252,17 @@ class Catalog
                                 }
                             }
 
+                            $categoryProductIds = $productIds;
                             $this->exportProduct->preloadRewriteUrls($storeId, $productIds);
+                            $this->categoryPathResolver->preloadCategoryPaths($storeId, $categoryProductIds);
 
                             foreach ($products as $product) {
                                 $parent = isset($childProducts[(int) $product->getId()]) ? $childProducts[(int) $product->getId()] : false;
                                 if ($generator->addProduct($product, $parent, $storeId)) {
+                                    if (!$hasActiveFeed) {
+                                        $generator->beginFeed($store);
+                                        $hasActiveFeed = true;
+                                    }
                                     $productCount++;
                                 }
                             }
@@ -279,7 +293,7 @@ class Catalog
 
                                 $productCount = 0;
                                 $fileIndex++;
-                                $generator->beginFeed($store);
+                                $hasActiveFeed = false;
                             }
                         } catch (Exception $e) {
                             $this->logger->error(
@@ -305,7 +319,7 @@ class Catalog
                         }
                     }
 
-                    if ($productCount > 0) {
+                    if ($hasActiveFeed && $productCount > 0) {
                         $feedData = $generator->finishFeed();
                         $totalFiles = ceil($this->totalPages / $pagesPerBatch);
                         $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);

--- a/Model/Export/Catalog.php
+++ b/Model/Export/Catalog.php
@@ -203,43 +203,41 @@ class Catalog
                                     $rows = $connection->fetchAll($select);
 
                                     if (!empty($rows)) {
-                                    $parentIdsToLoad = [];
                                         $parentMap = [];
                                         $emptyCollection = $this->productCollectionFactory->create();
-                                    $parentIds = array_values(array_unique(array_map('intval', array_column($rows, 'parent_id'))));
-                                    $parentCollection = $this->productCollectionFactory->create();
-                                    $parentCollection->setStoreId($storeId)
-                                        ->addAttributeToSelect(['url_key', 'url_path'])
-                                        ->addFieldToFilter('entity_id', ['in' => $parentIds]);
-                                    $loadedParentProducts = [];
-                                    foreach ($parentCollection as $parentProduct) {
-                                        $loadedParentProducts[(int) $parentProduct->getId()] = $parentProduct;
-                                    }
+                                        $parentIds = array_values(array_unique(array_map('intval', array_column($rows, 'parent_id'))));
+                                        $parentCollection = $this->productCollectionFactory->create();
+                                        $parentCollection->setStoreId($storeId)
+                                            ->addAttributeToSelect(['url_key', 'url_path'])
+                                            ->addFieldToFilter('entity_id', ['in' => $parentIds]);
+                                        $loadedParentProducts = [];
+                                        foreach ($parentCollection as $parentProduct) {
+                                            $loadedParentProducts[(int) $parentProduct->getId()] = $parentProduct;
+                                        }
 
                                         foreach ($rows as $row) {
-                                            $parentId = (int)$row['parent_id'];
-                                            $parentIdsToLoad[] = $parentId;
+                                            $parentId = (int) $row['parent_id'];
 
                                             if (!isset($parentMap[$parentId])) {
-                                            if (isset($loadedParentProducts[$parentId])) {
-                                                $parentProduct = $loadedParentProducts[$parentId];
-                                            } else {
-                                                $parentProduct = $emptyCollection->getNewEmptyItem();
-                                                $parentProduct->setData([
-                                                    'entity_id' => $parentId,
-                                                    'sku' => $row['parent_sku'],
-                                                    'type_id' => 'configurable',
-                                                    'store_id' => $storeId
-                                                ]);
-                                            }
+                                                if (isset($loadedParentProducts[$parentId])) {
+                                                    $parentProduct = $loadedParentProducts[$parentId];
+                                                } else {
+                                                    $parentProduct = $emptyCollection->getNewEmptyItem();
+                                                    $parentProduct->setData([
+                                                        'entity_id' => $parentId,
+                                                        'sku' => $row['parent_sku'],
+                                                        'type_id' => 'configurable',
+                                                        'store_id' => $storeId
+                                                    ]);
+                                                }
 
                                                 $parentMap[$parentId] = $parentProduct;
                                             }
 
-                                            $childProducts[(int)$row['product_id']] = $parentMap[$parentId];
+                                            $childProducts[(int) $row['product_id']] = $parentMap[$parentId];
                                         }
 
-                                        $productIds = array_merge($productIds, array_unique($parentIdsToLoad));
+                                        $productIds = array_merge($productIds, $parentIds);
 
                                         unset($emptyCollection, $parentMap);
                                     }

--- a/Model/Export/CategoryPathResolver.php
+++ b/Model/Export/CategoryPathResolver.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Model\Export;
+
+use Exception;
+use Magento\Framework\App\ResourceConnection;
+use TurnTo\SocialCommerce\Logger\Monolog;
+
+/**
+ * Resolves category paths for products in a page-sized batch.
+ */
+class CategoryPathResolver
+{
+    /**
+     * @var int|null
+     */
+    protected $cachedStoreId;
+
+    /**
+     * @var ResourceConnection
+     */
+    protected $resourceConnection;
+
+    /**
+     * @var Monolog
+     */
+    protected $logger;
+
+    /**
+     * @var array<int, array<int, array{id:string,name:string}>>
+     */
+    protected $categoryPathByProductId = [];
+
+    /**
+     * @var int|null
+     */
+    protected $nameAttributeId;
+
+    /**
+     * @var int|null
+     */
+    protected $categoryEntityTypeId;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param Monolog $logger
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        Monolog $logger
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Cache the deepest category path for each product for one store/page cycle.
+     *
+     * @param int|string $storeId
+     * @param int[] $productIds
+     * @return void
+     */
+    public function preloadCategoryPaths($storeId, array $productIds): void
+    {
+        $storeId = (int) $storeId;
+        $this->cachedStoreId = $storeId;
+        $this->categoryPathByProductId = [];
+
+        $productIds = array_values(array_filter(array_unique(array_map('intval', $productIds)), function ($id) {
+            return $id > 0;
+        }));
+
+        foreach ($productIds as $productId) {
+            $this->categoryPathByProductId[$productId] = [];
+        }
+
+        if (empty($productIds)) {
+            return;
+        }
+
+        try {
+            $connection = $this->resourceConnection->getConnection();
+
+            $categoryProductRows = $connection->fetchAll(
+                $connection->select()
+                    ->from(
+                        $connection->getTableName('catalog_category_product'),
+                        ['product_id', 'category_id']
+                    )
+                    ->where('product_id IN (?)', $productIds)
+                    ->order('category_id ASC')
+            );
+
+            if (empty($categoryProductRows)) {
+                return;
+            }
+
+            $categoriesByProduct = [];
+            $categoryIds = [];
+            foreach ($categoryProductRows as $row) {
+                $productId = (int) $row['product_id'];
+                $categoryId = (int) $row['category_id'];
+                if ($productId <= 0 || $categoryId <= 0) {
+                    continue;
+                }
+
+                $categoriesByProduct[$productId][] = $categoryId;
+                $categoryIds[] = $categoryId;
+            }
+
+            if (empty($categoryIds)) {
+                return;
+            }
+
+            $categoryIds = array_values(array_unique($categoryIds));
+            $entityTypeId = $this->getCatalogCategoryEntityTypeId($connection);
+            if ($entityTypeId === null) {
+                return;
+            }
+            $nameAttributeId = $this->getCatalogCategoryNameAttributeId($connection, $entityTypeId);
+            if ($nameAttributeId === null) {
+                return;
+            }
+
+            $pathRows = $connection->fetchAll(
+                $connection->select()
+                    ->from(
+                        $connection->getTableName('catalog_category_entity'),
+                        ['entity_id', 'path']
+                    )
+                    ->where('entity_id IN (?)', $categoryIds)
+            );
+            $pathByCategory = [];
+            foreach ($pathRows as $row) {
+                $pathByCategory[(int) $row['entity_id']] = (string) $row['path'];
+            }
+
+            $nameRows = $connection->fetchAll(
+                $connection->select()
+                    ->from(
+                        $connection->getTableName('catalog_category_entity_varchar'),
+                        ['entity_id', 'store_id', 'value']
+                    )
+                    ->where('attribute_id = ?', $nameAttributeId)
+                    ->where('entity_id IN (?)', $categoryIds)
+                    ->where('store_id IN (?)', [0, $storeId])
+            );
+            $nameByCategory = [];
+            foreach ($nameRows as $row) {
+                $categoryId = (int) $row['entity_id'];
+                $categoryStoreId = (int) $row['store_id'];
+                $categoryName = $row['value'];
+                if ($categoryName === null || $categoryName === '') {
+                    continue;
+                }
+
+                if ($categoryStoreId === $storeId || !isset($nameByCategory[$categoryId])) {
+                    $nameByCategory[$categoryId] = (string) $categoryName;
+                }
+            }
+
+            foreach ($categoriesByProduct as $productId => $categoriesForProduct) {
+                $bestDepth = -1;
+                $bestPath = [];
+
+                foreach ($categoriesForProduct as $categoryId) {
+                    $categoryPath = $pathByCategory[$categoryId] ?? '';
+                    $pathCategoryIds = $categoryPath === '' ?
+                        [$categoryId] :
+                        array_map('intval', array_filter(explode('/', $categoryPath), 'strlen'));
+                    $pathDepth = count($pathCategoryIds);
+                    if ($pathDepth <= $bestDepth) {
+                        continue;
+                    }
+                    $bestDepth = $pathDepth;
+                    $bestPath = $pathCategoryIds;
+                }
+
+                $categoryPath = [];
+                foreach ($bestPath as $pathCategoryId) {
+                    if (isset($nameByCategory[$pathCategoryId])) {
+                        $categoryPath[] = [
+                            'id' => (string) $pathCategoryId,
+                            'name' => (string) $nameByCategory[$pathCategoryId]
+                        ];
+                    }
+                }
+                $this->categoryPathByProductId[$productId] = $categoryPath;
+            }
+        } catch (Exception $e) {
+            $this->logger->error(
+                'Could not preload category paths for product feed',
+                [
+                    'exception' => $e,
+                    'store_id' => $storeId,
+                    'product_count' => count($productIds)
+                ]
+            );
+        }
+    }
+
+    /**
+     * @param int $storeId
+     * @param int $productId
+     * @return array{id:string,name:string}|null
+     */
+    public function getCategoryPath(int $storeId, int $productId): ?array
+    {
+        if ($this->cachedStoreId !== $storeId) {
+            return null;
+        }
+        if (!array_key_exists($productId, $this->categoryPathByProductId)) {
+            return null;
+        }
+
+        return $this->categoryPathByProductId[$productId];
+    }
+
+    /**
+     * @param \Magento\Framework\DB\Adapter\AdapterInterface $connection
+     * @return int|null
+     */
+    protected function getCatalogCategoryEntityTypeId($connection)
+    {
+        if ($this->categoryEntityTypeId !== null) {
+            return $this->categoryEntityTypeId;
+        }
+
+        $entityType = $connection->fetchOne(
+            $connection->select()
+                ->from(
+                    $connection->getTableName('eav_entity_type'),
+                    ['entity_type_id']
+                )
+                ->where('entity_type_code = ?', 'catalog_category')
+        );
+        if (empty($entityType)) {
+            return null;
+        }
+        $this->categoryEntityTypeId = (int) $entityType;
+        return $this->categoryEntityTypeId;
+    }
+
+    /**
+     * @param \Magento\Framework\DB\Adapter\AdapterInterface $connection
+     * @param int $entityTypeId
+     * @return int|null
+     */
+    protected function getCatalogCategoryNameAttributeId($connection, int $entityTypeId)
+    {
+        if ($this->nameAttributeId !== null) {
+            return $this->nameAttributeId;
+        }
+
+        $attributeId = $connection->fetchOne(
+            $connection->select()
+                ->from(
+                    $connection->getTableName('eav_attribute'),
+                    ['attribute_id']
+                )
+                ->where('attribute_code = ?', 'name')
+                ->where('entity_type_id = ?', $entityTypeId)
+        );
+        if (empty($attributeId)) {
+            return null;
+        }
+        $this->nameAttributeId = (int) $attributeId;
+        return $this->nameAttributeId;
+    }
+}

--- a/Model/Export/CategoryPathResolver.php
+++ b/Model/Export/CategoryPathResolver.php
@@ -136,8 +136,33 @@ class CategoryPathResolver
                     ->where('entity_id IN (?)', $categoryIds)
             );
             $pathByCategory = [];
+            $requiredCategoryIds = [];
             foreach ($pathRows as $row) {
-                $pathByCategory[(int) $row['entity_id']] = (string) $row['path'];
+                $entityId = (int) $row['entity_id'];
+                $path = (string) $row['path'];
+                $pathIds = [];
+                if ($path !== '') {
+                    foreach (explode('/', $path) as $pathCategoryId) {
+                        $categoryId = (int) $pathCategoryId;
+                        if ($categoryId > 0) {
+                            $pathIds[] = $categoryId;
+                            $requiredCategoryIds[$categoryId] = true;
+                        }
+                    }
+                }
+                if (empty($pathIds)) {
+                    $pathIds = [$entityId];
+                    $requiredCategoryIds[$entityId] = true;
+                }
+
+                $pathByCategory[$entityId] = $pathIds;
+            }
+            foreach ($categoryIds as $categoryId) {
+                $requiredCategoryIds[$categoryId] = true;
+            }
+            $allCategoryIds = array_map('intval', array_keys($requiredCategoryIds));
+            if (empty($allCategoryIds)) {
+                return;
             }
 
             $nameRows = $connection->fetchAll(
@@ -147,7 +172,7 @@ class CategoryPathResolver
                         ['entity_id', 'store_id', 'value']
                     )
                     ->where('attribute_id = ?', $nameAttributeId)
-                    ->where('entity_id IN (?)', $categoryIds)
+                    ->where('entity_id IN (?)', $allCategoryIds)
                     ->where('store_id IN (?)', [0, $storeId])
             );
             $nameByCategory = [];
@@ -169,10 +194,7 @@ class CategoryPathResolver
                 $bestPath = [];
 
                 foreach ($categoriesForProduct as $categoryId) {
-                    $categoryPath = $pathByCategory[$categoryId] ?? '';
-                    $pathCategoryIds = $categoryPath === '' ?
-                        [$categoryId] :
-                        array_map('intval', array_filter(explode('/', $categoryPath), 'strlen'));
+                    $pathCategoryIds = $pathByCategory[$categoryId] ?? [$categoryId];
                     $pathDepth = count($pathCategoryIds);
                     if ($pathDepth <= $bestDepth) {
                         continue;

--- a/Model/Export/Product.php
+++ b/Model/Export/Product.php
@@ -10,23 +10,25 @@ namespace TurnTo\SocialCommerce\Model\Export;
 use Exception;
 use Magento\Catalog\Model\Product as CatalogProduct;
 use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\UrlRewrite\Model\UrlFinderInterface;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 use TurnTo\SocialCommerce\Logger\Monolog;
 
+/**
+ * Export Product
+ */
 class Product
 {
     /**
-     * @var array
+     * @var array<int, string>|null
      */
     protected $rewriteUrls;
 
     /**
-     * @var
+     * @var int|null
      */
-    protected $storeId;
+    protected $cachedStoreId;
 
     /**
      * @var UrlFinderInterface
@@ -42,6 +44,11 @@ class Product
      */
     protected $logger;
 
+    /**
+     * @param UrlFinderInterface $urlFinder
+     * @param StoreManagerInterface $storeManager
+     * @param Monolog $logger
+     */
     public function __construct(
         UrlFinderInterface $urlFinder,
         StoreManagerInterface $storeManager,
@@ -54,55 +61,161 @@ class Product
 
     /**
      * Required to get beautified urls in cron (see https://github.com/magento/magento2/issues/3074)
+     *
      * @param CatalogProduct $product
-     * @param $storeId
+     * @param int|string $storeId
      * @return string
      */
     public function getProductUrl(CatalogProduct $product, $storeId)
     {
-        if (!$this->rewriteUrls){
-            $this->getRewriteUrls($storeId);
+        $storeId = (int) $storeId;
+
+        if ($this->cachedStoreId !== $storeId) {
+            $this->cachedStoreId = $storeId;
+            $this->rewriteUrls = null;
         }
 
-        if (isset($this->rewriteUrls[$product->getId()])) {
-            return $this->rewriteUrls[$product->getId()];
+        if ($this->rewriteUrls !== null) {
+            $productId = $product->getId();
+            if (isset($this->rewriteUrls[$productId])) {
+                return $this->rewriteUrls[$productId];
+            }
         }
 
-        return $product->getProductUrl();
+        return $this->resolveProductUrlWithoutPreloadedRewrites($product, $storeId);
     }
 
     /**
-     * @param $relativeUrl
-     * @param $storeId
+     * Native URL resolution with explicit store scope (covers order export, CLI, and cache misses).
+     *
+     * @param CatalogProduct $product
+     * @param int $storeId
      * @return string
-     * @throws NoSuchEntityException
      */
-    protected function getAbsoluteUrl($relativeUrl, $storeId)
+    protected function resolveProductUrlWithoutPreloadedRewrites(CatalogProduct $product, int $storeId)
     {
-        $storeUrl = $this->storeManager->getStore($storeId)->getBaseUrl();
+        $originalStoreId = $product->getStoreId();
+        try {
+            $product->setStoreId($storeId);
+            return $product->getProductUrl();
+        } finally {
+            $product->setStoreId($originalStoreId);
+        }
+    }
+
+    /**
+     * Build an absolute URL from a store-relative request path.
+     *
+     * @param string $relativeUrl
+     * @param string $storeUrl
+     * @return string
+     */
+    protected function getAbsoluteUrl($relativeUrl, $storeUrl)
+    {
         return rtrim($storeUrl, '/') . '/' . ltrim($relativeUrl, '/');
     }
 
     /**
-     * @param $storeId
+     * Batch-load product rewrites for the given store to avoid repeated lookups during catalog feed generation.
+     *
+     * When several rewrites exist per product (category paths), the canonical product rewrite is preferred.
+     *
+     * @param int|string $storeId
+     * @param int[] $productIds
      * @return void
      */
-    protected function getRewriteUrls($storeId)
+    public function preloadRewriteUrls($storeId, array $productIds)
     {
+        $storeId = (int) $storeId;
+        $this->cachedStoreId = $storeId;
         $this->rewriteUrls = [];
-        $urlRewrites = $this->urlFinder->findAllByData(
-            [
-                UrlRewrite::ENTITY_TYPE =>
-                    ProductUrlRewriteGenerator::ENTITY_TYPE,
-                UrlRewrite::STORE_ID => $storeId
-            ]
-        );
+
+        if ($productIds === []) {
+            return;
+        }
+
+        $productIds = array_values(array_unique(array_map('intval', $productIds)));
+
+        $candidates = [];
+        try {
+            $urlRewrites = $this->urlFinder->findAllByData(
+                [
+                    UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
+                    UrlRewrite::STORE_ID => $storeId,
+                    UrlRewrite::REDIRECT_TYPE => 0,
+                    UrlRewrite::ENTITY_ID => $productIds,
+                ]
+            );
+        } catch (Exception $e) {
+            $this->logger->error($e->getMessage(), ['exception' => $e]);
+            return;
+        }
+
+        try {
+            $storeUrl = $this->storeManager->getStore($storeId)->getBaseUrl();
+        } catch (Exception $e) {
+            $this->logger->error($e->getMessage(), ['exception' => $e]);
+            return;
+        }
+
         foreach ($urlRewrites as $urlRewrite) {
             try {
-                $this->rewriteUrls[$urlRewrite->getEntityId()] = $this->getAbsoluteUrl($urlRewrite->getRequestPath(), $storeId);
+                $entityId = $urlRewrite->getEntityId();
+                $candidates[$entityId][] = [
+                    'url' => $this->getAbsoluteUrl($urlRewrite->getRequestPath(), $storeUrl),
+                    'rewrite' => $urlRewrite,
+                ];
             } catch (Exception $e) {
-                $this->logger->error($e);
+                $this->logger->error($e->getMessage(), ['exception' => $e]);
             }
         }
+
+        foreach ($candidates as $entityId => $rows) {
+            $this->rewriteUrls[$entityId] = $this->pickPreferredProductRewriteUrl($rows);
+        }
+    }
+
+    /**
+     * Prefer canonical product rewrites (no category metadata) over category-scoped paths.
+     *
+     * @param array<int, array{url: string, rewrite: UrlRewrite}> $rows
+     * @return string
+     */
+    protected function pickPreferredProductRewriteUrl(array $rows)
+    {
+        foreach ($rows as $row) {
+            if ($this->isCanonicalProductRewrite($row['rewrite'])) {
+                return $row['url'];
+            }
+        }
+
+        // Fallback: Sort deterministically to ensure consistent exports
+        // Prefer shorter URLs (fewer category segments), then sort alphabetically
+        usort($rows, function ($a, $b) {
+            $pathA = $a['rewrite']->getRequestPath();
+            $pathB = $b['rewrite']->getRequestPath();
+
+            $lengthComparison = strlen($pathA) <=> strlen($pathB);
+            if ($lengthComparison !== 0) {
+                return $lengthComparison;
+            }
+
+            return strcmp($pathA, $pathB);
+        });
+
+        return $rows[0]['url'];
+    }
+
+    /**
+     * Whether the rewrite is the product-level URL (not scoped to a category path).
+     *
+     * @param UrlRewrite $rewrite
+     * @return bool
+     */
+    protected function isCanonicalProductRewrite(UrlRewrite $rewrite)
+    {
+        $metadata = $rewrite->getMetadata() ?? [];
+
+        return empty($metadata['category_id']) && empty($metadata['redirect_type']);
     }
 }

--- a/Plugin/Block/Product/View/Type/ConfigurablePlugin.php
+++ b/Plugin/Block/Product/View/Type/ConfigurablePlugin.php
@@ -7,11 +7,11 @@ declare(strict_types=1);
 
 namespace TurnTo\SocialCommerce\Plugin\Block\Product\View\Type;
 
-use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ProductRepository;
 use Magento\ConfigurableProduct\Block\Product\View\Type\Configurable;
 use Magento\Framework\Exception\NoSuchEntityException;
 use TurnTo\SocialCommerce\Model\Config;
+use TurnTo\SocialCommerce\Model\Product as TurnToProduct;
 
 class ConfigurablePlugin
 {
@@ -21,20 +21,29 @@ class ConfigurablePlugin
     protected $config;
 
     /**
-     * @var Product
+     * @var ProductRepository
      */
     protected $product;
+    /**
+     * @var TurnToProduct
+     */
+    protected $turnToProduct;
 
     /**
      * ConfigurablePlugin constructor.
      *
      * @param Config            $config
      * @param ProductRepository $product
+     * @param TurnToProduct     $turnToProduct
      */
-    public function __construct(Config $config, ProductRepository $product)
-    {
+    public function __construct(
+        Config $config,
+        ProductRepository $product,
+        TurnToProduct $turnToProduct
+    ) {
         $this->config = $config;
         $this->product = $product;
+        $this->turnToProduct = $turnToProduct;
     }
 
     /**
@@ -50,13 +59,13 @@ class ConfigurablePlugin
         $result = json_decode($result,true);
         $parentProduct =  $this->product->getById($result['productId']);
         $result['useChild'] = $this->config->getUseChildSku();
-        $result['parentSku'] = $parentProduct->getSku();
+        $result['parentSku'] = $this->turnToProduct->turnToSafeEncoding($parentProduct->getSku());
 
         $children = $parentProduct->getTypeInstance()->getUsedProducts($parentProduct);
         if ($children) {
             $result['childSkuMap'] = [];
             foreach ($children as $child) {
-                $result['childSkuMap'][$child->getId()] = $child->getSku();
+                $result['childSkuMap'][$child->getId()] = $this->turnToProduct->turnToSafeEncoding($child->getSku());
             }
         }
 

--- a/Service/Feed/AbstractFeedGenerator.php
+++ b/Service/Feed/AbstractFeedGenerator.php
@@ -267,9 +267,9 @@ abstract class AbstractFeedGenerator implements FeedGeneratorInterface
     public function getItemGroupId($product, $parent)
     {
         if ($parent) {
-            return $parent->getSku();
+            return $this->product->turnToSafeEncoding($parent->getSku());
         } else {
-            return $product->getSku();
+            return $this->product->turnToSafeEncoding($product->getSku());
         }
     }
 }

--- a/Service/Feed/AbstractFeedGenerator.php
+++ b/Service/Feed/AbstractFeedGenerator.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Service\Feed;
+
+use Exception;
+use Magento\Catalog\Api\Data\ProductAttributeInterface;
+use Magento\Catalog\Helper\Image;
+use Magento\Catalog\Model\Category;
+use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Eav\Model\Config as EavConfig;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Store\Api\Data\StoreInterface;
+use TurnTo\SocialCommerce\Api\FeedGeneratorInterface;
+use TurnTo\SocialCommerce\Logger\Monolog;
+use TurnTo\SocialCommerce\Model\Config;
+use TurnTo\SocialCommerce\Model\Config\Gtin;
+use TurnTo\SocialCommerce\Model\Product;
+
+/**
+ * Shared helpers for TurnTo product feed generators (sanitization, GTIN, images, categories).
+ */
+abstract class AbstractFeedGenerator implements FeedGeneratorInterface
+{
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    /**
+     * @var Gtin
+     */
+    protected $gtinConfig;
+
+    /**
+     * @var Image
+     */
+    protected $imageHelper;
+
+    /**
+     * @var Product
+     */
+    protected $product;
+
+    /**
+     * @var EavConfig
+     */
+    protected $eavConfig;
+
+    /**
+     * @var PriceCurrencyInterface
+     */
+    protected $priceCurrency;
+
+    /**
+     * @var Monolog
+     */
+    protected $logger;
+
+    /**
+     * @param Config $config
+     * @param Gtin $gtinConfig
+     * @param Image $imageHelper
+     * @param Product $product TurnTo product helper (SKU encoding, etc.)
+     * @param EavConfig $eavConfig
+     * @param PriceCurrencyInterface $priceCurrency
+     * @param Monolog $logger
+     */
+    public function __construct(
+        Config $config,
+        Gtin $gtinConfig,
+        Image $imageHelper,
+        Product $product,
+        EavConfig $eavConfig,
+        PriceCurrencyInterface $priceCurrency,
+        Monolog $logger
+    ) {
+        $this->config = $config;
+        $this->gtinConfig = $gtinConfig;
+        $this->imageHelper = $imageHelper;
+        $this->product = $product;
+        $this->eavConfig = $eavConfig;
+        $this->priceCurrency = $priceCurrency;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Escapes special characters for xml use
+     *
+     * @param string $dirtyString
+     *
+     * @return string
+     */
+    protected function sanitizeData($dirtyString)
+    {
+        if (is_string($dirtyString)) {
+            return htmlspecialchars($dirtyString, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        }
+        return $dirtyString;
+    }
+
+    /**
+     * Resolves a product attribute value, returning the display label for
+     * EAV select/multiselect attributes instead of the raw option ID.
+     *
+     * @param CatalogProduct $product
+     * @param string $attributeCode
+     * @return string|null
+     */
+    protected function getProductAttributeValue(CatalogProduct $product, string $attributeCode)
+    {
+        if (empty($attributeCode)) {
+            return null;
+        }
+
+        try {
+            $attribute = $this->eavConfig->getAttribute(ProductAttributeInterface::ENTITY_TYPE_CODE, $attributeCode);
+            if ($attribute && $attribute->usesSource()) {
+                $label = $product->getAttributeText($attributeCode);
+                if (is_array($label)) {
+                    return implode(', ', $label);
+                }
+                return (string)$label;
+            }
+        } catch (Exception $e) {
+            $this->logger->error(
+                'Error retrieving product attribute',
+                [
+                    'exception' => $e,
+                    'attributeCode' => $attributeCode,
+                    'productId' => $product->getId()
+                ]
+            );
+        }
+
+        $value = $product->getData($attributeCode);
+        if (is_array($value)) {
+            return implode(', ', array_map('strval', $value));
+        }
+        return !empty($value) ? (string)$value : null;
+    }
+
+    /**
+     * @param CatalogProduct $product
+     * @param array $gtinMap
+     * @return string|null
+     */
+    public function getGtinValue($product, $gtinMap)
+    {
+        $gtinAttributes = [
+            Gtin::UPC_ATTRIBUTE,
+            Gtin::EAN_ATTRIBUTE,
+            Gtin::JAN_ATTRIBUTE,
+            Gtin::ISBN_ATTRIBUTE,
+            Gtin::ASIN_ATTRIBUTE
+        ];
+        foreach ($gtinAttributes as $key) {
+            if (isset($gtinMap[$key])) {
+                return $this->getProductAttributeValue($product, $gtinMap[$key]);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param CatalogProduct $product
+     * @return string
+     */
+    public function getProductImageUrl($product)
+    {
+        $productImageUrl = '';
+        try {
+            $productImage = $product->getImage();
+            if ($productImage) {
+                $productImageUrl = $this->imageHelper->init($product, 'product_page_main_image')
+                    ->setImageFile($productImage)->getUrl();
+            }
+        } catch (Exception $e) {
+            $this->logger->error(
+                'Error retrieving product image',
+                [
+                    'exception' => $e,
+                    'productId' => $product->getId()
+                ]
+            );
+        }
+
+        return $productImageUrl;
+    }
+
+    /**
+     * Gets the deepest tree for given product and returns as "rootNodeName > branchNodeName > leafNodeName"
+     *
+     * @param CatalogProduct $product
+     * @param int|StoreInterface|string $storeId
+     * @return string
+     * @throws LocalizedException
+     */
+    protected function getCategoryTreeString(CatalogProduct $product, $storeId)
+    {
+        $categoryName = '';
+        $categories = $product->getCategoryCollection()->setStoreId($storeId)->addAttributeToSelect('name');
+        $deepestLength = 0;
+        $deepestTree = [];
+
+        foreach ($categories as $category) {
+            $tempTree = $this->getCategoryBranch($category);
+            $treeLength = count($tempTree);
+            if ($treeLength > $deepestLength) {
+                $deepestLength = $treeLength;
+                $deepestTree = $tempTree;
+            }
+        }
+
+        foreach (array_reverse($deepestTree) as $node) {
+            $nodeName = $node->getName();
+            if (!empty($nodeName)) {
+                if (!empty($categoryName)) {
+                    $categoryName .= ' > ';
+                }
+                $categoryName .= $node->getName();
+            }
+        }
+
+        return $categoryName;
+    }
+
+    /**
+     * Recursively walks category chain from leaf to root while writing the traversed branch to an array
+     *
+     * @param Category $category
+     * @param array $categoryBranch
+     *
+     * @return array
+     */
+    protected function getCategoryBranch(Category $category, array $categoryBranch = [])
+    {
+        try {
+            $parent = $category->getParentCategory();
+        } catch (NoSuchEntityException $isRootEntity) {
+            $parent = null;
+        } finally {
+            $categoryBranch[] = $category;
+            if (isset($parent)) {
+                return $this->getCategoryBranch($parent, $categoryBranch);
+            } else {
+                return $categoryBranch;
+            }
+        }
+    }
+
+    /**
+     * Get item group ID for a given product
+     *
+     * @param CatalogProduct $product
+     * @param CatalogProduct|bool $parent
+     *
+     * @return string
+     */
+    public function getItemGroupId($product, $parent)
+    {
+        if ($parent) {
+            return $parent->getSku();
+        } else {
+            return $product->getSku();
+        }
+    }
+}

--- a/Service/Feed/AbstractFeedGenerator.php
+++ b/Service/Feed/AbstractFeedGenerator.php
@@ -21,6 +21,7 @@ use TurnTo\SocialCommerce\Api\FeedGeneratorInterface;
 use TurnTo\SocialCommerce\Logger\Monolog;
 use TurnTo\SocialCommerce\Model\Config;
 use TurnTo\SocialCommerce\Model\Config\Gtin;
+use TurnTo\SocialCommerce\Model\Export\CategoryPathResolver;
 use TurnTo\SocialCommerce\Model\Product;
 
 /**
@@ -64,6 +65,11 @@ abstract class AbstractFeedGenerator implements FeedGeneratorInterface
     protected $logger;
 
     /**
+     * @var CategoryPathResolver
+     */
+    protected $categoryPathResolver;
+
+    /**
      * @param Config $config
      * @param Gtin $gtinConfig
      * @param Image $imageHelper
@@ -79,7 +85,8 @@ abstract class AbstractFeedGenerator implements FeedGeneratorInterface
         Product $product,
         EavConfig $eavConfig,
         PriceCurrencyInterface $priceCurrency,
-        Monolog $logger
+        Monolog $logger,
+        CategoryPathResolver $categoryPathResolver
     ) {
         $this->config = $config;
         $this->gtinConfig = $gtinConfig;
@@ -88,6 +95,7 @@ abstract class AbstractFeedGenerator implements FeedGeneratorInterface
         $this->eavConfig = $eavConfig;
         $this->priceCurrency = $priceCurrency;
         $this->logger = $logger;
+        $this->categoryPathResolver = $categoryPathResolver;
     }
 
     /**
@@ -205,7 +213,62 @@ abstract class AbstractFeedGenerator implements FeedGeneratorInterface
      */
     protected function getCategoryTreeString(CatalogProduct $product, $storeId)
     {
+        $categoryTree = $this->getCategoryPathNodes($product, $storeId);
         $categoryName = '';
+
+        foreach ($categoryTree as $node) {
+            $nodeName = $node['name'] ?? '';
+            if (!empty($nodeName)) {
+                if (!empty($categoryName)) {
+                    $categoryName .= ' > ';
+                }
+                $categoryName .= $nodeName;
+            }
+        }
+
+        return $categoryName;
+    }
+
+    /**
+     * Gets the category path as arrays using either preloaded resolver data or fallback recursion.
+     *
+     * @param CatalogProduct $product
+     * @param int|StoreInterface|string $storeId
+     * @return array<array{id:string,name:string}>
+     * @throws LocalizedException
+     */
+    protected function getCategoryPathNodes(CatalogProduct $product, $storeId): array
+    {
+        $productId = (int) $product->getId();
+        if ($productId > 0 && $this->categoryPathResolver instanceof CategoryPathResolver) {
+            $categoryPath = $this->categoryPathResolver->getCategoryPath((int) $storeId, $productId);
+            if ($categoryPath !== null) {
+                return $categoryPath;
+            }
+        }
+
+        $categoryTree = $this->getDeepestCategoryTree($product, $storeId);
+        $categoryPath = [];
+        foreach ($categoryTree as $node) {
+            $categoryPath[] = [
+                'id' => (string) $node->getId(),
+                'name' => (string) $node->getName()
+            ];
+        }
+
+        return $categoryPath;
+    }
+
+    /**
+     * Gets the deepest category tree for given product in root-to-leaf order.
+     *
+     * @param CatalogProduct $product
+     * @param int|StoreInterface|string $storeId
+     * @return array
+     * @throws LocalizedException
+     */
+    protected function getDeepestCategoryTree(CatalogProduct $product, $storeId)
+    {
         $categories = $product->getCategoryCollection()->setStoreId($storeId)->addAttributeToSelect('name');
         $deepestLength = 0;
         $deepestTree = [];
@@ -219,17 +282,7 @@ abstract class AbstractFeedGenerator implements FeedGeneratorInterface
             }
         }
 
-        foreach (array_reverse($deepestTree) as $node) {
-            $nodeName = $node->getName();
-            if (!empty($nodeName)) {
-                if (!empty($categoryName)) {
-                    $categoryName .= ' > ';
-                }
-                $categoryName .= $node->getName();
-            }
-        }
-
-        return $categoryName;
+        return array_reverse($deepestTree);
     }
 
     /**

--- a/Service/Feed/AbstractFeedGenerator.php
+++ b/Service/Feed/AbstractFeedGenerator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace TurnTo\SocialCommerce\Service\Feed;
 
 use Exception;
+use LogicException;
 use Magento\Catalog\Api\Data\ProductAttributeInterface;
 use Magento\Catalog\Helper\Image;
 use Magento\Catalog\Model\Category;
@@ -70,6 +71,16 @@ abstract class AbstractFeedGenerator implements FeedGeneratorInterface
     protected $categoryPathResolver;
 
     /**
+     * @var resource|null
+     */
+    protected $stream;
+
+    /**
+     * @var bool
+     */
+    protected $isFeedOpen = false;
+
+    /**
      * @param Config $config
      * @param Gtin $gtinConfig
      * @param Image $imageHelper
@@ -77,6 +88,7 @@ abstract class AbstractFeedGenerator implements FeedGeneratorInterface
      * @param EavConfig $eavConfig
      * @param PriceCurrencyInterface $priceCurrency
      * @param Monolog $logger
+     * @param CategoryPathResolver $categoryPathResolver
      */
     public function __construct(
         Config $config,
@@ -324,5 +336,44 @@ abstract class AbstractFeedGenerator implements FeedGeneratorInterface
         } else {
             return $this->product->turnToSafeEncoding($product->getSku());
         }
+    }
+
+    /**
+     * Ensure the feed stream is initialized and valid before reading it back.
+     *
+     * @return void
+     */
+    protected function assertFeedStreamReady(): void
+    {
+        if (!$this->isFeedOpen) {
+            throw new LogicException('Feed stream is not initialized. Call beginFeed() before finishFeed().');
+        }
+
+        if (!is_resource($this->stream)) {
+            $this->cleanupStream();
+            throw new LogicException('Feed stream is invalid. Call beginFeed() again before finishFeed().');
+        }
+    }
+
+    /**
+     * Release stream resources and reset stream state.
+     *
+     * @return void
+     */
+    protected function cleanupStream(): void
+    {
+        if (is_resource($this->stream)) {
+            fclose($this->stream);
+        }
+        $this->isFeedOpen = false;
+        $this->stream = null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isFeedOpen(): bool
+    {
+        return $this->isFeedOpen;
     }
 }

--- a/Service/Feed/CommerceFeedGenerator.php
+++ b/Service/Feed/CommerceFeedGenerator.php
@@ -266,12 +266,12 @@ class CommerceFeedGenerator extends AbstractFeedGenerator
                     $product
                 );
                 foreach ($selections as $selection) {
-                    $members[] = $selection->getSku();
+                    $members[] = $this->product->turnToSafeEncoding($selection->getSku());
                 }
             } elseif ($typeId === 'grouped') {
                 $associatedProducts = $product->getTypeInstance()->getAssociatedProducts($product);
                 foreach ($associatedProducts as $child) {
-                    $members[] = $child->getSku();
+                    $members[] = $this->product->turnToSafeEncoding($child->getSku());
                 }
             }
         } catch (Exception $e) {

--- a/Service/Feed/CommerceFeedGenerator.php
+++ b/Service/Feed/CommerceFeedGenerator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace TurnTo\SocialCommerce\Service\Feed;
 
 use Exception;
+use LogicException;
 use Magento\Catalog\Helper\Image;
 use Magento\Catalog\Model\Product as CatalogProduct;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
@@ -36,6 +37,10 @@ class CommerceFeedGenerator extends AbstractFeedGenerator
      * @var resource|null Writable stream for the in-progress feed body
      */
     protected $stream;
+    /**
+     * @var bool Tracks whether the feed stream has been initialized and not yet finalized
+     */
+    protected $isFeedOpen = false;
 
     /**
      * @param Config $config
@@ -45,7 +50,8 @@ class CommerceFeedGenerator extends AbstractFeedGenerator
      * @param EavConfig $eavConfig
      * @param PriceCurrencyInterface $priceCurrency
      * @param Monolog $logger
-     * @param ExportProduct $exportProduct Resolves storefront product URLs for feed links
+     * @param CategoryPathResolver $categoryPathResolver
+     * @param ExportProduct $exportProduct
      */
     public function __construct(
         Config $config,
@@ -85,6 +91,11 @@ class CommerceFeedGenerator extends AbstractFeedGenerator
     public function beginFeed(StoreInterface $store)
     {
         $this->stream = fopen('php://temp', 'r+');
+        if ($this->stream === false) {
+            $this->isFeedOpen = false;
+            throw new LogicException('Failed to initialize feed stream.');
+        }
+        $this->isFeedOpen = true;
         $header = implode("\t", [
             'id', 'title', 'item_url', 'image_url', 'stock', 'active',
             'category_path_json', 'virtual_parent_code', 'members', 'brand',
@@ -101,7 +112,16 @@ class CommerceFeedGenerator extends AbstractFeedGenerator
         try {
             $line = $this->generateProductLine($product, $storeId, $parent);
             if ($line) {
-                fwrite($this->stream, $line . "\n");
+                if (fwrite($this->stream, $line . "\n") === false) {
+                    $this->logger->error(
+                        'Failed to write product to feed',
+                        [
+                            'product_id' => $product->getId(),
+                            'store_id' => $storeId
+                        ]
+                    );
+                    return false;
+                }
                 return true;
             }
         } catch (Exception $entryException) {
@@ -123,10 +143,30 @@ class CommerceFeedGenerator extends AbstractFeedGenerator
      */
     public function finishFeed()
     {
-        rewind($this->stream);
-        $content = stream_get_contents($this->stream);
-        fclose($this->stream);
+        if (!$this->isFeedOpen) {
+            throw new LogicException('Feed stream is not initialized. Call beginFeed() before finishFeed().');
+        }
+
+        try {
+            rewind($this->stream);
+            $content = stream_get_contents($this->stream);
+        } finally {
+            if (is_resource($this->stream)) {
+                fclose($this->stream);
+            }
+            $this->isFeedOpen = false;
+            $this->stream = null;
+        }
+
         return $content;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isFeedOpen(): bool
+    {
+        return $this->isFeedOpen;
     }
 
     /**

--- a/Service/Feed/CommerceFeedGenerator.php
+++ b/Service/Feed/CommerceFeedGenerator.php
@@ -93,12 +93,13 @@ class CommerceFeedGenerator extends AbstractFeedGenerator
     /**
      * @inheritdoc
      */
-    public function addProduct($product, $parent = null, $storeId = null)
+    public function addProduct($product, $parent = null, $storeId = null): bool
     {
         try {
             $line = $this->generateProductLine($product, $storeId, $parent);
             if ($line) {
                 fwrite($this->stream, $line . "\n");
+                return true;
             }
         } catch (Exception $entryException) {
             $this->logger->error(
@@ -108,7 +109,10 @@ class CommerceFeedGenerator extends AbstractFeedGenerator
                     'productSKU' => $product->getSku()
                 ]
             );
+            return false;
         }
+
+        return false;
     }
 
     /**
@@ -120,6 +124,21 @@ class CommerceFeedGenerator extends AbstractFeedGenerator
         $content = stream_get_contents($this->stream);
         fclose($this->stream);
         return $content;
+    }
+
+    /**
+     * Sanitize text fields for tab-delimited feeds to prevent column/row shifting.
+     *
+     * @param string|null $text
+     * @return string
+     */
+    protected function sanitizeTextField(?string $text): string
+    {
+        if ($text === null || $text === '') {
+            return '';
+        }
+
+        return trim(preg_replace('/[\t\r\n]+/', ' ', $text));
     }
 
     /**
@@ -151,7 +170,7 @@ class CommerceFeedGenerator extends AbstractFeedGenerator
         if (empty($productName)) {
             throw new Exception('Product must have a valid name');
         }
-        $productName = str_replace("\n", "", $productName);
+        $productName = $this->sanitizeTextField($productName);
 
         $turntoDisable = $product->getCustomAttribute('turnto_disabled') ?
             $product->getCustomAttribute('turnto_disabled')->getValue() :
@@ -194,16 +213,16 @@ class CommerceFeedGenerator extends AbstractFeedGenerator
         $gtinMap = $this->gtinConfig->getGtinAttributesMap($storeId);
         if (!empty($gtinMap)) {
             if (isset($gtinMap[Gtin::BRAND_ATTRIBUTE])) {
-                $brand = $this->getProductAttributeValue($product, $gtinMap[Gtin::BRAND_ATTRIBUTE]) ?: '';
+                $brand = $this->sanitizeTextField((string) $this->getProductAttributeValue($product, $gtinMap[Gtin::BRAND_ATTRIBUTE]));
             }
             if (isset($gtinMap[Gtin::UPC_ATTRIBUTE])) {
-                $upc = $this->getProductAttributeValue($product, $gtinMap[Gtin::UPC_ATTRIBUTE]) ?: '';
+                $upc = $this->sanitizeTextField((string) $this->getProductAttributeValue($product, $gtinMap[Gtin::UPC_ATTRIBUTE]));
             }
             if (isset($gtinMap[Gtin::EAN_ATTRIBUTE])) {
-                $ean = $this->getProductAttributeValue($product, $gtinMap[Gtin::EAN_ATTRIBUTE]) ?: '';
+                $ean = $this->sanitizeTextField((string) $this->getProductAttributeValue($product, $gtinMap[Gtin::EAN_ATTRIBUTE]));
             }
             if (isset($gtinMap[Gtin::MPN_ATTRIBUTE])) {
-                $mpn = $this->getProductAttributeValue($product, $gtinMap[Gtin::MPN_ATTRIBUTE]) ?: '';
+                $mpn = $this->sanitizeTextField((string) $this->getProductAttributeValue($product, $gtinMap[Gtin::MPN_ATTRIBUTE]));
             }
         }
 

--- a/Service/Feed/CommerceFeedGenerator.php
+++ b/Service/Feed/CommerceFeedGenerator.php
@@ -18,6 +18,7 @@ use TurnTo\SocialCommerce\Logger\Monolog;
 use TurnTo\SocialCommerce\Model\Config;
 use TurnTo\SocialCommerce\Model\Config\Gtin;
 use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
+use TurnTo\SocialCommerce\Model\Export\CategoryPathResolver;
 use TurnTo\SocialCommerce\Model\Export\Product as ExportProduct;
 use TurnTo\SocialCommerce\Model\Product;
 
@@ -54,6 +55,7 @@ class CommerceFeedGenerator extends AbstractFeedGenerator
         EavConfig $eavConfig,
         PriceCurrencyInterface $priceCurrency,
         Monolog $logger,
+        CategoryPathResolver $categoryPathResolver,
         ExportProduct $exportProduct
     ) {
         parent::__construct(
@@ -63,7 +65,8 @@ class CommerceFeedGenerator extends AbstractFeedGenerator
             $product,
             $eavConfig,
             $priceCurrency,
-            $logger
+            $logger,
+            $categoryPathResolver
         );
         $this->exportProduct = $exportProduct;
     }
@@ -185,16 +188,18 @@ class CommerceFeedGenerator extends AbstractFeedGenerator
         }
 
         $categoryPathJson = '';
-        $categoryName = $this->getCategoryTreeString($product, $storeId);
-        if (!empty($categoryName)) {
-            $categories = explode(' > ', $categoryName);
-            $catArray = [];
-            foreach ($categories as $index => $cat) {
+        $categoryTree = $this->getCategoryPathNodes($product, $storeId);
+        $catArray = [];
+        foreach ($categoryTree as $category) {
+            $categoryName = $category['name'] ?? '';
+            if (!empty($categoryName)) {
                 $catArray[] = [
-                    'id' => (string)(($index + 1) * 10),
-                    'name' => $cat
+                    'id' => (string) $category['id'],
+                    'name' => $categoryName
                 ];
             }
+        }
+        if (!empty($catArray)) {
             $categoryPathJson = json_encode($catArray);
         }
 

--- a/Service/Feed/CommerceFeedGenerator.php
+++ b/Service/Feed/CommerceFeedGenerator.php
@@ -34,15 +34,6 @@ class CommerceFeedGenerator extends AbstractFeedGenerator
     protected $exportProduct;
 
     /**
-     * @var resource|null Writable stream for the in-progress feed body
-     */
-    protected $stream;
-    /**
-     * @var bool Tracks whether the feed stream has been initialized and not yet finalized
-     */
-    protected $isFeedOpen = false;
-
-    /**
      * @param Config $config
      * @param Gtin $gtinConfig
      * @param Image $imageHelper
@@ -143,30 +134,16 @@ class CommerceFeedGenerator extends AbstractFeedGenerator
      */
     public function finishFeed()
     {
-        if (!$this->isFeedOpen) {
-            throw new LogicException('Feed stream is not initialized. Call beginFeed() before finishFeed().');
-        }
+        $this->assertFeedStreamReady();
 
         try {
             rewind($this->stream);
             $content = stream_get_contents($this->stream);
         } finally {
-            if (is_resource($this->stream)) {
-                fclose($this->stream);
-            }
-            $this->isFeedOpen = false;
-            $this->stream = null;
+            $this->cleanupStream();
         }
 
         return $content;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function isFeedOpen(): bool
-    {
-        return $this->isFeedOpen;
     }
 
     /**

--- a/Service/Feed/CommerceFeedGenerator.php
+++ b/Service/Feed/CommerceFeedGenerator.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Service\Feed;
+
+use Exception;
+use Magento\Catalog\Helper\Image;
+use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Eav\Model\Config as EavConfig;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Store\Api\Data\StoreInterface;
+use TurnTo\SocialCommerce\Logger\Monolog;
+use TurnTo\SocialCommerce\Model\Config;
+use TurnTo\SocialCommerce\Model\Config\Gtin;
+use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
+use TurnTo\SocialCommerce\Model\Export\Product as ExportProduct;
+use TurnTo\SocialCommerce\Model\Product;
+
+/**
+ * Tab-delimited Commerce product feed generator for TurnTo.
+ */
+class CommerceFeedGenerator extends AbstractFeedGenerator
+{
+    /**
+     * @var ExportProduct
+     */
+    protected $exportProduct;
+
+    /**
+     * @var resource|null Writable stream for the in-progress feed body
+     */
+    protected $stream;
+
+    /**
+     * @param Config $config
+     * @param Gtin $gtinConfig
+     * @param Image $imageHelper
+     * @param Product $product
+     * @param EavConfig $eavConfig
+     * @param PriceCurrencyInterface $priceCurrency
+     * @param Monolog $logger
+     * @param ExportProduct $exportProduct Resolves storefront product URLs for feed links
+     */
+    public function __construct(
+        Config $config,
+        Gtin $gtinConfig,
+        Image $imageHelper,
+        Product $product,
+        EavConfig $eavConfig,
+        PriceCurrencyInterface $priceCurrency,
+        Monolog $logger,
+        ExportProduct $exportProduct
+    ) {
+        parent::__construct(
+            $config,
+            $gtinConfig,
+            $imageHelper,
+            $product,
+            $eavConfig,
+            $priceCurrency,
+            $logger
+        );
+        $this->exportProduct = $exportProduct;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getFeedStyle(): string
+    {
+        return FeedFormat::COMMERCE;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function beginFeed(StoreInterface $store)
+    {
+        $this->stream = fopen('php://temp', 'r+');
+        $header = implode("\t", [
+            'id', 'title', 'item_url', 'image_url', 'stock', 'active',
+            'category_path_json', 'virtual_parent_code', 'members', 'brand',
+            'currency', 'price', 'upc', 'ean', 'mpn'
+        ]) . "\n";
+        fwrite($this->stream, $header);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addProduct($product, $parent = null, $storeId = null)
+    {
+        try {
+            $line = $this->generateProductLine($product, $storeId, $parent);
+            if ($line) {
+                fwrite($this->stream, $line . "\n");
+            }
+        } catch (Exception $entryException) {
+            $this->logger->error(
+                'Product failed to be added to feed',
+                [
+                    'exception' => $entryException,
+                    'productSKU' => $product->getSku()
+                ]
+            );
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function finishFeed()
+    {
+        rewind($this->stream);
+        $content = stream_get_contents($this->stream);
+        fclose($this->stream);
+        return $content;
+    }
+
+    /**
+     * Build one tab-separated line for the commerce feed.
+     *
+     * @param CatalogProduct $product
+     * @param int|string|null $storeId
+     * @param bool|CatalogProduct|null $parent
+     * @return string
+     * @throws Exception
+     */
+    protected function generateProductLine($product, $storeId, $parent)
+    {
+        if (empty($product)) {
+            throw new Exception('Product can not be null or empty');
+        }
+
+        $sku = $this->product->turnToSafeEncoding($product->getSku());
+        if (empty($sku)) {
+            throw new Exception('Product must have a valid sku');
+        }
+
+        $productUrl = $parent ? $this->exportProduct->getProductUrl($parent, $storeId) : $this->exportProduct->getProductUrl($product, $storeId);
+        if (empty($productUrl)) {
+            throw new Exception('Product must have a valid store-product url');
+        }
+
+        $productName = $product->getName();
+        if (empty($productName)) {
+            throw new Exception('Product must have a valid name');
+        }
+        $productName = str_replace("\n", "", $productName);
+
+        $turntoDisable = $product->getCustomAttribute('turnto_disabled') ?
+            $product->getCustomAttribute('turnto_disabled')->getValue() :
+            false;
+        $active = $turntoDisable ? '0' : (($product->getStatus() == Status::STATUS_ENABLED) ? '1' : '0');
+
+        $stock = '0';
+        $isInStock = (bool) $product->getData('is_in_stock');
+        if ($isInStock) {
+            $qty = (float) $product->getData('qty');
+            $stock = (string)(int)$qty;
+        }
+
+        $categoryPathJson = '';
+        $categoryName = $this->getCategoryTreeString($product, $storeId);
+        if (!empty($categoryName)) {
+            $categories = explode(' > ', $categoryName);
+            $catArray = [];
+            foreach ($categories as $index => $cat) {
+                $catArray[] = [
+                    'id' => (string)(($index + 1) * 10),
+                    'name' => $cat
+                ];
+            }
+            $categoryPathJson = json_encode($catArray);
+        }
+
+        $virtualParentCode = '';
+        $itemGroupId = $this->getItemGroupId($product, $parent);
+        if ($itemGroupId !== $sku) {
+            $virtualParentCode = $itemGroupId;
+        }
+
+        $members = $this->getMembers($product);
+
+        $brand = '';
+        $upc = '';
+        $ean = '';
+        $mpn = '';
+        $gtinMap = $this->gtinConfig->getGtinAttributesMap($storeId);
+        if (!empty($gtinMap)) {
+            if (isset($gtinMap[Gtin::BRAND_ATTRIBUTE])) {
+                $brand = $this->getProductAttributeValue($product, $gtinMap[Gtin::BRAND_ATTRIBUTE]) ?: '';
+            }
+            if (isset($gtinMap[Gtin::UPC_ATTRIBUTE])) {
+                $upc = $this->getProductAttributeValue($product, $gtinMap[Gtin::UPC_ATTRIBUTE]) ?: '';
+            }
+            if (isset($gtinMap[Gtin::EAN_ATTRIBUTE])) {
+                $ean = $this->getProductAttributeValue($product, $gtinMap[Gtin::EAN_ATTRIBUTE]) ?: '';
+            }
+            if (isset($gtinMap[Gtin::MPN_ATTRIBUTE])) {
+                $mpn = $this->getProductAttributeValue($product, $gtinMap[Gtin::MPN_ATTRIBUTE]) ?: '';
+            }
+        }
+
+        $price = $this->priceCurrency->convertAndRound($product->getFinalPrice(), $storeId);
+        $currencyCode = $this->priceCurrency->getCurrency($storeId)->getCurrencyCode();
+
+        $data = [
+            $sku,
+            $productName,
+            $productUrl,
+            $this->getProductImageUrl($product),
+            $stock,
+            $active,
+            $categoryPathJson,
+            $virtualParentCode,
+            $members,
+            $brand,
+            $currencyCode,
+            $price,
+            $upc,
+            $ean,
+            $mpn
+        ];
+
+        return implode("\t", $data);
+    }
+
+    /**
+     * @param CatalogProduct $product
+     * @return string
+     */
+    protected function getMembers($product)
+    {
+        $members = [];
+        $typeId = $product->getTypeId();
+
+        try {
+            if ($typeId === 'bundle') {
+                $selections = $product->getTypeInstance()->getSelectionsCollection(
+                    $product->getTypeInstance()->getOptionsIds($product),
+                    $product
+                );
+                foreach ($selections as $selection) {
+                    $members[] = $selection->getSku();
+                }
+            } elseif ($typeId === 'grouped') {
+                $associatedProducts = $product->getTypeInstance()->getAssociatedProducts($product);
+                foreach ($associatedProducts as $child) {
+                    $members[] = $child->getSku();
+                }
+            }
+        } catch (Exception $e) {
+            $this->logger->error(
+                'Error retrieving members for product',
+                [
+                    'exception' => $e,
+                    'productId' => $product->getId()
+                ]
+            );
+        }
+
+        return implode(',', array_unique($members));
+    }
+}

--- a/Service/Feed/FeedGeneratorFactory.php
+++ b/Service/Feed/FeedGeneratorFactory.php
@@ -26,23 +26,25 @@ class FeedGeneratorFactory
     }
 
     /**
-     * @param string $format
+     * @param string|null $format
      * @return FeedGeneratorInterface
      * @throws InvalidArgumentException
      */
-    public function create(string $format)
+    public function create(?string $format)
     {
-        if (isset($this->generators[$format])) {
-            $factory = $this->generators[$format];
-            $generator = $factory->create();
-            if (!$generator instanceof FeedGeneratorInterface) {
-                throw new InvalidArgumentException(
-                    get_class($generator) . ' doesn\'t implement \TurnTo\SocialCommerce\Api\FeedGeneratorInterface'
-                );
-            }
-            return $generator;
+        if ($format === null || !array_key_exists($format, $this->generators)) {
+            throw new InvalidArgumentException('Invalid feed format: ' . ($format ?? 'null'));
         }
 
-        throw new InvalidArgumentException('Invalid feed format: ' . $format);
+        $factory = $this->generators[$format];
+        $generator = $factory->create();
+
+        if (!$generator instanceof FeedGeneratorInterface) {
+            throw new InvalidArgumentException(
+                get_class($generator) . ' doesn\'t implement \TurnTo\SocialCommerce\Api\FeedGeneratorInterface'
+            );
+        }
+
+        return $generator;
     }
 }

--- a/Service/Feed/FeedGeneratorFactory.php
+++ b/Service/Feed/FeedGeneratorFactory.php
@@ -13,12 +13,12 @@ use TurnTo\SocialCommerce\Api\FeedGeneratorInterface;
 class FeedGeneratorFactory
 {
     /**
-     * @var FeedGeneratorInterface[]
+     * @var array
      */
     protected $generators;
 
     /**
-     * @param FeedGeneratorInterface[] $generators
+     * @param array $generators
      */
     public function __construct(array $generators = [])
     {
@@ -33,7 +33,14 @@ class FeedGeneratorFactory
     public function create(string $format)
     {
         if (isset($this->generators[$format])) {
-            return $this->generators[$format];
+            $factory = $this->generators[$format];
+            $generator = $factory->create();
+            if (!$generator instanceof FeedGeneratorInterface) {
+                throw new InvalidArgumentException(
+                    get_class($generator) . ' doesn\'t implement \TurnTo\SocialCommerce\Api\FeedGeneratorInterface'
+                );
+            }
+            return $generator;
         }
 
         throw new InvalidArgumentException('Invalid feed format: ' . $format);

--- a/Service/Feed/FeedGeneratorFactory.php
+++ b/Service/Feed/FeedGeneratorFactory.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Service\Feed;
+
+use InvalidArgumentException;
+use TurnTo\SocialCommerce\Api\FeedGeneratorInterface;
+
+class FeedGeneratorFactory
+{
+    /**
+     * @var FeedGeneratorInterface[]
+     */
+    protected $generators;
+
+    /**
+     * @param FeedGeneratorInterface[] $generators
+     */
+    public function __construct(array $generators = [])
+    {
+        $this->generators = $generators;
+    }
+
+    /**
+     * @param string $format
+     * @return FeedGeneratorInterface
+     * @throws InvalidArgumentException
+     */
+    public function create(string $format)
+    {
+        if (isset($this->generators[$format])) {
+            return $this->generators[$format];
+        }
+
+        throw new InvalidArgumentException('Invalid feed format: ' . $format);
+    }
+}

--- a/Service/Feed/GoogleFeedGenerator.php
+++ b/Service/Feed/GoogleFeedGenerator.php
@@ -9,6 +9,7 @@ namespace TurnTo\SocialCommerce\Service\Feed;
 
 use DateTimeZone;
 use Exception;
+use LogicException;
 use Magento\Catalog\Helper\Image;
 use Magento\Catalog\Model\Product as CatalogProduct;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
@@ -50,6 +51,7 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
      * @param PriceCurrencyInterface $priceCurrency
      * @param Monolog $logger
      * @param DateTimeFactory $dateTimeFactory
+     * @param CategoryPathResolver $categoryPathResolver
      * @param ExportProduct $exportProduct Resolves storefront product URLs for feed links
      */
     public function __construct(
@@ -82,6 +84,10 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
      * @var resource|null Writable stream for the in-progress feed body
      */
     protected $stream;
+    /**
+     * @var bool Tracks whether the feed stream has been initialized and not yet finalized
+     */
+    protected $isFeedOpen = false;
 
     /**
      * @inheritdoc
@@ -97,6 +103,11 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
     public function beginFeed(StoreInterface $store)
     {
         $this->stream = fopen('php://temp', 'r+');
+        if ($this->stream === false) {
+            $this->isFeedOpen = false;
+            throw new LogicException('Failed to initialize feed stream.');
+        }
+        $this->isFeedOpen = true;
         $header = '<?xml version="1.0" encoding="UTF-8"?>' . "\n" .
                   '<feed xmlns="http://www.w3.org/2005/Atom" xmlns:g="http://base.google.com/ns/1.0" xml:lang="en-US">' . "\n" .
                   '<title>' . $this->sanitizeData($store->getName() . ' - Google Product Atom 1.0 Feed') . '</title>' . "\n" .
@@ -121,14 +132,23 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
                 '',
                 $entryXml
             );
-            fwrite($this->stream, trim($entryXml) . "\n");
+            if (fwrite($this->stream, trim($entryXml) . "\n") === false) {
+                $this->logger->error(
+                    'Failed to write product to feed',
+                    [
+                        'product_id' => $product->getId(),
+                        'store_id' => $storeId
+                    ]
+                );
+                return false;
+            }
             return true;
         } catch (Exception $e) {
             $this->logger->error(
                 'Product failed to be added to feed',
                 [
                     'exception' => $e,
-                    'productSKU' => $product ? $product->getSku() : null
+                    'productSKU' => $product->getSku()
                 ]
             );
         }
@@ -141,11 +161,31 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
      */
     public function finishFeed()
     {
-        fwrite($this->stream, '</feed>');
-        rewind($this->stream);
-        $content = stream_get_contents($this->stream);
-        fclose($this->stream);
+        if (!$this->isFeedOpen) {
+            throw new LogicException('Feed stream is not initialized. Call beginFeed() before finishFeed().');
+        }
+
+        try {
+            fwrite($this->stream, '</feed>');
+            rewind($this->stream);
+            $content = stream_get_contents($this->stream);
+        } finally {
+            if (is_resource($this->stream)) {
+                fclose($this->stream);
+            }
+            $this->isFeedOpen = false;
+            $this->stream = null;
+        }
+
         return $content;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isFeedOpen(): bool
+    {
+        return $this->isFeedOpen;
     }
 
     /**

--- a/Service/Feed/GoogleFeedGenerator.php
+++ b/Service/Feed/GoogleFeedGenerator.php
@@ -107,7 +107,7 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
     /**
      * @inheritdoc
      */
-    public function addProduct($product, $parent = null, $storeId = null)
+    public function addProduct($product, $parent = null, $storeId = null): bool
     {
         try {
             $entry = new SimpleXMLElement('<entry xmlns="http://www.w3.org/2005/Atom" xmlns:g="http://base.google.com/ns/1.0"/>');
@@ -119,6 +119,7 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
                 $entryXml
             );
             fwrite($this->stream, trim($entryXml) . "\n");
+            return true;
         } catch (Exception $e) {
             $this->logger->error(
                 'Product failed to be added to feed',
@@ -127,7 +128,10 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
                     'productSKU' => $product ? $product->getSku() : null
                 ]
             );
+            return false;
         }
+
+        return false;
     }
 
     /**

--- a/Service/Feed/GoogleFeedGenerator.php
+++ b/Service/Feed/GoogleFeedGenerator.php
@@ -128,7 +128,6 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
                     'productSKU' => $product ? $product->getSku() : null
                 ]
             );
-            return false;
         }
 
         return false;

--- a/Service/Feed/GoogleFeedGenerator.php
+++ b/Service/Feed/GoogleFeedGenerator.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Service\Feed;
+
+use DateTimeZone;
+use Exception;
+use Magento\Catalog\Helper\Image;
+use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Eav\Model\Config as EavConfig;
+use Magento\Framework\Intl\DateTimeFactory;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Api\Data\StoreInterface;
+use SimpleXMLElement;
+use TurnTo\SocialCommerce\Logger\Monolog;
+use TurnTo\SocialCommerce\Model\Config;
+use TurnTo\SocialCommerce\Model\Config\Gtin;
+use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
+use TurnTo\SocialCommerce\Model\Export\Product as ExportProduct;
+use TurnTo\SocialCommerce\Model\Product;
+
+/**
+ * Google Shopping Atom 1.0 product feed generator.
+ */
+class GoogleFeedGenerator extends AbstractFeedGenerator
+{
+    /**
+     * @var DateTimeFactory
+     */
+    protected $dateTimeFactory;
+
+    /**
+     * @var ExportProduct
+     */
+    protected $exportProduct;
+
+    /**
+     * @param Config $config
+     * @param Gtin $gtinConfig
+     * @param Image $imageHelper
+     * @param Product $product
+     * @param EavConfig $eavConfig
+     * @param PriceCurrencyInterface $priceCurrency
+     * @param Monolog $logger
+     * @param DateTimeFactory $dateTimeFactory
+     * @param ExportProduct $exportProduct Resolves storefront product URLs for feed links
+     */
+    public function __construct(
+        Config $config,
+        Gtin $gtinConfig,
+        Image $imageHelper,
+        Product $product,
+        EavConfig $eavConfig,
+        PriceCurrencyInterface $priceCurrency,
+        Monolog $logger,
+        DateTimeFactory $dateTimeFactory,
+        ExportProduct $exportProduct
+    ) {
+        parent::__construct(
+            $config,
+            $gtinConfig,
+            $imageHelper,
+            $product,
+            $eavConfig,
+            $priceCurrency,
+            $logger
+        );
+        $this->dateTimeFactory = $dateTimeFactory;
+        $this->exportProduct = $exportProduct;
+    }
+
+    /**
+     * @var resource|null Writable stream for the in-progress feed body
+     */
+    protected $stream;
+
+    /**
+     * @inheritdoc
+     */
+    public function getFeedStyle(): string
+    {
+        return FeedFormat::GOOGLE_PRODUCT;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function beginFeed(StoreInterface $store)
+    {
+        $this->stream = fopen('php://temp', 'r+');
+        $header = '<?xml version="1.0" encoding="UTF-8"?>' . "\n" .
+                  '<feed xmlns="http://www.w3.org/2005/Atom" xmlns:g="http://base.google.com/ns/1.0" xml:lang="en-US">' . "\n" .
+                  '<title>' . $this->sanitizeData($store->getName() . ' - Google Product Atom 1.0 Feed') . '</title>' . "\n" .
+                  '<link>' . $this->sanitizeData($store->getBaseUrl(UrlInterface::URL_TYPE_LINK)) . '</link>' . "\n" .
+                  '<updated>' . $this->dateTimeFactory->create('now', new DateTimeZone('UTC'))->format(DATE_ATOM) . '</updated>' . "\n" .
+                  '<author><name>TurnTo</name></author>' . "\n" .
+                  '<id>' . $this->sanitizeData($store->getBaseUrl(UrlInterface::URL_TYPE_WEB)) . '</id>' . "\n";
+        fwrite($this->stream, $header);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addProduct($product, $parent = null, $storeId = null)
+    {
+        $entry = new SimpleXMLElement('<entry/>');
+        $this->addProductToAtomFeed($entry, $product, $storeId, $parent);
+        $entryXml = $entry->asXML();
+        $entryXml = str_replace('<?xml version="1.0"?>', '', $entryXml);
+        fwrite($this->stream, trim($entryXml) . "\n");
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function finishFeed()
+    {
+        fwrite($this->stream, '</feed>');
+        rewind($this->stream);
+        $content = stream_get_contents($this->stream);
+        fclose($this->stream);
+        return $content;
+    }
+
+    /**
+     * Adds a Magento catalog product to a Google Products ATOM 1.0 xml feed
+     *
+     * @param SimpleXMLElement $entry
+     * @param CatalogProduct $product
+     * @param int|string $storeId
+     * @param bool|CatalogProduct $parent
+     * @return void
+     * @throws Exception
+     */
+    protected function addProductToAtomFeed($entry, $product, $storeId, $parent)
+    {
+        if (empty($product)) {
+            throw new Exception('Product can not be null or empty');
+        }
+
+        $sku = $this->product->turnToSafeEncoding($product->getSku());
+        if (empty($sku)) {
+            throw new Exception('Product must have a valid sku');
+        }
+
+        $productUrl = $parent ? $this->exportProduct->getProductUrl($parent, $storeId) : $this->exportProduct->getProductUrl($product, $storeId);
+        if (empty($productUrl)) {
+            throw new Exception('Product must have a valid store-product url');
+        }
+
+        $productName = $product->getName();
+        if (empty($productName)) {
+            throw new Exception('Product must have a valid name');
+        }
+        $productName = str_replace("\n", "", $productName);
+
+        $entry->addChild('id', $this->sanitizeData($sku));
+
+        $identifierExists = 'FALSE';
+        $gtinMap = $this->gtinConfig->getGtinAttributesMap($storeId);
+        if (!empty($gtinMap)) {
+            $gtinValue = $this->getGtinValue($product, $gtinMap);
+            if (!empty($gtinValue)) {
+                $entry->addChild('g:gtin', $this->sanitizeData($gtinValue));
+            }
+            $brand = null;
+            if (isset($gtinMap[Gtin::BRAND_ATTRIBUTE])) {
+                $brand = $this->getProductAttributeValue($product, $gtinMap[Gtin::BRAND_ATTRIBUTE]);
+                if (!empty($brand)) {
+                    $entry->addChild('g:brand', $this->sanitizeData($brand));
+                }
+            }
+            $mpn = null;
+            if (isset($gtinMap[Gtin::MPN_ATTRIBUTE])) {
+                $mpn = $this->getProductAttributeValue($product, $gtinMap[Gtin::MPN_ATTRIBUTE]);
+                if (!empty($mpn)) {
+                    $entry->addChild('g:mpn', $this->sanitizeData($mpn));
+                }
+            }
+            if (!empty($brand) && (!empty($gtinValue) || !empty($mpn))) {
+                $identifierExists = 'TRUE';
+            }
+        }
+
+        $entry->addChild('g:identifier_exists', $identifierExists);
+        $entry->addChild('g:link', $this->sanitizeData($productUrl));
+        $entry->addChild('g:title', $this->sanitizeData($productName));
+
+        $categoryName = $this->getCategoryTreeString($product, $storeId);
+        if (!empty($categoryName)) {
+            $cleanCategoryName = $this->sanitizeData($categoryName);
+            $entry->addChild('g:google_product_category', $cleanCategoryName);
+            $entry->addChild('g:product_type', $cleanCategoryName);
+        }
+
+        // Availability is normally determined by status, but can be overridden by custom "turnto_disabled" attribute
+        $turntoDisable = $product->getCustomAttribute('turnto_disabled') ?
+            $product->getCustomAttribute('turnto_disabled')->getValue() :
+            false;
+        $availability = $turntoDisable ? 'out of stock' :
+            (($product->getStatus() == Status::STATUS_ENABLED) ? 'in stock' : 'out of stock');
+
+        $entry->addChild('g:availability', $availability);
+        $productImageUrl = $this->getProductImageUrl($product);
+        $entry->addChild('g:image_link', $this->sanitizeData($productImageUrl));
+        $entry->addChild('g:condition', 'new');
+        $price = $this->priceCurrency->convertAndRound($product->getFinalPrice(), $storeId);
+        $currencyCode = $this->priceCurrency->getCurrency($storeId)->getCurrencyCode();
+        $entry->addChild('g:price', $price . ' ' . $currencyCode);
+        $itemGroupId = $this->getItemGroupId($product, $parent);
+        $entry->addChild('g:item_group_id', $this->sanitizeData($itemGroupId));
+    }
+}

--- a/Service/Feed/GoogleFeedGenerator.php
+++ b/Service/Feed/GoogleFeedGenerator.php
@@ -22,6 +22,7 @@ use TurnTo\SocialCommerce\Logger\Monolog;
 use TurnTo\SocialCommerce\Model\Config;
 use TurnTo\SocialCommerce\Model\Config\Gtin;
 use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
+use TurnTo\SocialCommerce\Model\Export\CategoryPathResolver;
 use TurnTo\SocialCommerce\Model\Export\Product as ExportProduct;
 use TurnTo\SocialCommerce\Model\Product;
 
@@ -60,6 +61,7 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
         PriceCurrencyInterface $priceCurrency,
         Monolog $logger,
         DateTimeFactory $dateTimeFactory,
+        CategoryPathResolver $categoryPathResolver,
         ExportProduct $exportProduct
     ) {
         parent::__construct(
@@ -69,7 +71,8 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
             $product,
             $eavConfig,
             $priceCurrency,
-            $logger
+            $logger,
+            $categoryPathResolver
         );
         $this->dateTimeFactory = $dateTimeFactory;
         $this->exportProduct = $exportProduct;

--- a/Service/Feed/GoogleFeedGenerator.php
+++ b/Service/Feed/GoogleFeedGenerator.php
@@ -109,11 +109,21 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
      */
     public function addProduct($product, $parent = null, $storeId = null)
     {
-        $entry = new SimpleXMLElement('<entry/>');
-        $this->addProductToAtomFeed($entry, $product, $storeId, $parent);
-        $entryXml = $entry->asXML();
-        $entryXml = str_replace('<?xml version="1.0"?>', '', $entryXml);
-        fwrite($this->stream, trim($entryXml) . "\n");
+        try {
+            $entry = new SimpleXMLElement('<entry/>');
+            $this->addProductToAtomFeed($entry, $product, $storeId, $parent);
+            $entryXml = $entry->asXML();
+            $entryXml = str_replace('<?xml version="1.0"?>', '', $entryXml);
+            fwrite($this->stream, trim($entryXml) . "\n");
+        } catch (Exception $e) {
+            $this->logger->error(
+                'Product failed to be added to feed',
+                [
+                    'exception' => $e,
+                    'productSKU' => $product ? $product->getSku() : null
+                ]
+            );
+        }
     }
 
     /**

--- a/Service/Feed/GoogleFeedGenerator.php
+++ b/Service/Feed/GoogleFeedGenerator.php
@@ -80,14 +80,6 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
         $this->exportProduct = $exportProduct;
     }
 
-    /**
-     * @var resource|null Writable stream for the in-progress feed body
-     */
-    protected $stream;
-    /**
-     * @var bool Tracks whether the feed stream has been initialized and not yet finalized
-     */
-    protected $isFeedOpen = false;
 
     /**
      * @inheritdoc
@@ -161,31 +153,17 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
      */
     public function finishFeed()
     {
-        if (!$this->isFeedOpen) {
-            throw new LogicException('Feed stream is not initialized. Call beginFeed() before finishFeed().');
-        }
+        $this->assertFeedStreamReady();
 
         try {
             fwrite($this->stream, '</feed>');
             rewind($this->stream);
             $content = stream_get_contents($this->stream);
         } finally {
-            if (is_resource($this->stream)) {
-                fclose($this->stream);
-            }
-            $this->isFeedOpen = false;
-            $this->stream = null;
+            $this->cleanupStream();
         }
 
         return $content;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function isFeedOpen(): bool
-    {
-        return $this->isFeedOpen;
     }
 
     /**

--- a/Service/Feed/GoogleFeedGenerator.php
+++ b/Service/Feed/GoogleFeedGenerator.php
@@ -110,10 +110,14 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
     public function addProduct($product, $parent = null, $storeId = null)
     {
         try {
-            $entry = new SimpleXMLElement('<entry/>');
+            $entry = new SimpleXMLElement('<entry xmlns="http://www.w3.org/2005/Atom" xmlns:g="http://base.google.com/ns/1.0"/>');
             $this->addProductToAtomFeed($entry, $product, $storeId, $parent);
             $entryXml = $entry->asXML();
-            $entryXml = str_replace('<?xml version="1.0"?>', '', $entryXml);
+            $entryXml = str_replace(
+                ['<?xml version="1.0"?>', ' xmlns="http://www.w3.org/2005/Atom"', ' xmlns:g="http://base.google.com/ns/1.0"'],
+                '',
+                $entryXml
+            );
             fwrite($this->stream, trim($entryXml) . "\n");
         } catch (Exception $e) {
             $this->logger->error(
@@ -174,23 +178,24 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
 
         $identifierExists = 'FALSE';
         $gtinMap = $this->gtinConfig->getGtinAttributesMap($storeId);
+        $gNs = 'http://base.google.com/ns/1.0';
         if (!empty($gtinMap)) {
             $gtinValue = $this->getGtinValue($product, $gtinMap);
             if (!empty($gtinValue)) {
-                $entry->addChild('g:gtin', $this->sanitizeData($gtinValue));
+                $entry->addChild('g:gtin', $this->sanitizeData($gtinValue), $gNs);
             }
             $brand = null;
             if (isset($gtinMap[Gtin::BRAND_ATTRIBUTE])) {
                 $brand = $this->getProductAttributeValue($product, $gtinMap[Gtin::BRAND_ATTRIBUTE]);
                 if (!empty($brand)) {
-                    $entry->addChild('g:brand', $this->sanitizeData($brand));
+                    $entry->addChild('g:brand', $this->sanitizeData($brand), $gNs);
                 }
             }
             $mpn = null;
             if (isset($gtinMap[Gtin::MPN_ATTRIBUTE])) {
                 $mpn = $this->getProductAttributeValue($product, $gtinMap[Gtin::MPN_ATTRIBUTE]);
                 if (!empty($mpn)) {
-                    $entry->addChild('g:mpn', $this->sanitizeData($mpn));
+                    $entry->addChild('g:mpn', $this->sanitizeData($mpn), $gNs);
                 }
             }
             if (!empty($brand) && (!empty($gtinValue) || !empty($mpn))) {
@@ -198,15 +203,15 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
             }
         }
 
-        $entry->addChild('g:identifier_exists', $identifierExists);
-        $entry->addChild('g:link', $this->sanitizeData($productUrl));
-        $entry->addChild('g:title', $this->sanitizeData($productName));
+        $entry->addChild('g:identifier_exists', $identifierExists, $gNs);
+        $entry->addChild('g:link', $this->sanitizeData($productUrl), $gNs);
+        $entry->addChild('g:title', $this->sanitizeData($productName), $gNs);
 
         $categoryName = $this->getCategoryTreeString($product, $storeId);
         if (!empty($categoryName)) {
             $cleanCategoryName = $this->sanitizeData($categoryName);
-            $entry->addChild('g:google_product_category', $cleanCategoryName);
-            $entry->addChild('g:product_type', $cleanCategoryName);
+            $entry->addChild('g:google_product_category', $cleanCategoryName, $gNs);
+            $entry->addChild('g:product_type', $cleanCategoryName, $gNs);
         }
 
         // Availability is normally determined by status, but can be overridden by custom "turnto_disabled" attribute
@@ -216,14 +221,14 @@ class GoogleFeedGenerator extends AbstractFeedGenerator
         $availability = $turntoDisable ? 'out of stock' :
             (($product->getStatus() == Status::STATUS_ENABLED) ? 'in stock' : 'out of stock');
 
-        $entry->addChild('g:availability', $availability);
+        $entry->addChild('g:availability', $availability, $gNs);
         $productImageUrl = $this->getProductImageUrl($product);
-        $entry->addChild('g:image_link', $this->sanitizeData($productImageUrl));
-        $entry->addChild('g:condition', 'new');
+        $entry->addChild('g:image_link', $this->sanitizeData($productImageUrl), $gNs);
+        $entry->addChild('g:condition', 'new', $gNs);
         $price = $this->priceCurrency->convertAndRound($product->getFinalPrice(), $storeId);
         $currencyCode = $this->priceCurrency->getCurrency($storeId)->getCurrencyCode();
-        $entry->addChild('g:price', $price . ' ' . $currencyCode);
+        $entry->addChild('g:price', $price . ' ' . $currencyCode, $gNs);
         $itemGroupId = $this->getItemGroupId($product, $parent);
-        $entry->addChild('g:item_group_id', $this->sanitizeData($itemGroupId));
+        $entry->addChild('g:item_group_id', $this->sanitizeData($itemGroupId), $gNs);
     }
 }

--- a/Service/GoogleFeed/Client.php
+++ b/Service/GoogleFeed/Client.php
@@ -9,6 +9,8 @@ namespace TurnTo\SocialCommerce\Service\GoogleFeed;
 
 use Exception;
 use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\RequestOptions;
 use SimpleXMLElement;
 use TurnTo\SocialCommerce\Api\FeedClient;
@@ -23,6 +25,11 @@ class Client implements FeedClient
      * Response body from TurnTo servers on successful operation
      */
     const TURNTO_SUCCESS_RESPONSE = 'SUCCESS';
+    const MAX_TRANSMISSION_ATTEMPTS = 3;
+    /**
+     * 500ms base retry delay, doubled for each retry attempt.
+     */
+    const TRANSMISSION_RETRY_DELAY_MICROSECONDS = 500000;
     /**
      * @var Config
      */
@@ -54,66 +61,127 @@ class Client implements FeedClient
 
     /**
      * @inheritdoc
+     * @throws GuzzleException
      */
     public function transmitFeedFile($feedData, string $fileName, string $feedStyle, string $storeCode)
     {
-        $responseContents = 'win';
-        try {
-            if ($feedStyle === FeedFormat::GOOGLE_PRODUCT) {
-                if ($feedData instanceof SimpleXMLElement) {
-                    $feedData = $feedData->asXML();
+        for ($attempt = 1; $attempt <= self::MAX_TRANSMISSION_ATTEMPTS; $attempt++) {
+            $responseContents = '';
+            $statusCode = null;
+            $shouldRetry = false;
+            $transmissionContext = [
+                'store_code' => $storeCode,
+                'feed_style' => $feedStyle,
+                'file_name' => $fileName,
+                'attempt' => $attempt,
+                'max_attempts' => self::MAX_TRANSMISSION_ATTEMPTS
+            ];
+
+            try {
+                if ($feedStyle === FeedFormat::GOOGLE_PRODUCT) {
+                    if ($feedData instanceof SimpleXMLElement) {
+                        $feedData = $feedData->asXML();
+                    }
+                    $path = "turnto/google-product_storecode_$storeCode.xml";
+                    $this->file->writeFile($path, $feedData);
+                } elseif ($feedStyle === FeedFormat::COMMERCE) {
+                    $path = "turnto/commerce-product_storecode_$storeCode.tsv";
+                    $this->file->writeFile($path, $feedData);
                 }
-                $path = "turnto/google-product_storecode_$storeCode.xml";
-                $this->file->writeFile($path, $feedData);
-            } elseif ($feedStyle === FeedFormat::COMMERCE) {
-                $path = "turnto/commerce-product_storecode_$storeCode.tsv";
-                $this->file->writeFile($path, $feedData);
-            }
 
-            $response = $this->client->request('POST', $this->config->getConfigValue(Config::PRODUCT_FEED_SUBMISSION_URL, $storeCode), [
-                RequestOptions::MULTIPART => [
+                $response = $this->client->request(
+                    'POST',
+                    $this->config->getConfigValue(Config::PRODUCT_FEED_SUBMISSION_URL, $storeCode),
                     [
-                        'name' => 'siteKey',
-                        'contents' => $this->config->getSiteKey($storeCode)
-                    ],
-                    [
-                        'name' => 'authKey',
-                        'contents' => $this->config->getAuthorizationKey($storeCode)
-                    ],
-                    [
-                        'name' => 'feedStyle',
-                        'contents' => $feedStyle
-                    ],
-                    [
-                        'name'     => 'file',
-                        'contents' => $feedData,
-                        'filename' => $fileName
+                        RequestOptions::HTTP_ERRORS => false,
+                        RequestOptions::MULTIPART => [
+                            [
+                                'name' => 'siteKey',
+                                'contents' => $this->config->getSiteKey($storeCode)
+                            ],
+                            [
+                                'name' => 'authKey',
+                                'contents' => $this->config->getAuthorizationKey($storeCode)
+                            ],
+                            [
+                                'name' => 'feedStyle',
+                                'contents' => $feedStyle
+                            ],
+                            [
+                                'name' => 'file',
+                                'contents' => $feedData,
+                                'filename' => $fileName
+                            ]
+                        ]
                     ]
-                ]
-            ]);
+                );
 
-            $responseContents = $response->getBody()->getContents();
-            if ($feedStyle === FeedFormat::GOOGLE_PRODUCT) {
-                $path = "turnto/google-product_storecode_{$storeCode}_request.xml";
-                $this->file->writeFile($path, $responseContents);
-            } elseif ($feedStyle === FeedFormat::COMMERCE) {
-                $path = "turnto/commerce-product_storecode_{$storeCode}_request.txt";
-                $this->file->writeFile($path, $responseContents);
-            }
+                $statusCode = $response->getStatusCode();
+                $responseContents = $response->getBody()->getContents();
 
-            //It is possible to get a status 200 message who's body is an error message from TurnTo
-            if ($responseContents !== self::TURNTO_SUCCESS_RESPONSE) {
-                throw new Exception("Emplifi $fileName submission failed with message: $responseContents");
+                if ($feedStyle === FeedFormat::GOOGLE_PRODUCT) {
+                    $path = "turnto/google-product_storecode_{$storeCode}_request.xml";
+                    $this->file->writeFile($path, $responseContents);
+                } elseif ($feedStyle === FeedFormat::COMMERCE) {
+                    $path = "turnto/commerce-product_storecode_{$storeCode}_request.txt";
+                    $this->file->writeFile($path, $responseContents);
+                }
+
+                if ($statusCode < 200 || $statusCode >= 300) {
+                    $shouldRetry = $statusCode === 429 || ($statusCode >= 500 && $statusCode < 600);
+                    throw new Exception(sprintf(
+                        'Emplifi %s submission failed with status %d and response %s',
+                        $fileName,
+                        $statusCode,
+                        $responseContents
+                    ));
+                }
+
+                if (trim($responseContents) !== self::TURNTO_SUCCESS_RESPONSE) {
+                    throw new Exception(sprintf(
+                        'Emplifi %s submission failed with message: %s',
+                        $fileName,
+                        $responseContents
+                    ));
+                }
+
+                return;
+            } catch (Exception $e) {
+                if ($e instanceof TransferException) {
+                    $shouldRetry = true;
+                }
+
+                $transmissionContext['exception'] = $e;
+                $transmissionContext['status_code'] = $statusCode;
+                $transmissionContext['response'] = $responseContents;
+                if ($shouldRetry && $attempt < self::MAX_TRANSMISSION_ATTEMPTS) {
+                    $this->logger->warning(
+                        'TurnTo catalog export transmission failed; retrying',
+                        $transmissionContext
+                    );
+                    usleep($this->getRetryDelayMicroseconds($attempt));
+                    continue;
+                }
+
+                $this->logger->error(
+                    'TurnTo catalog feed transmission failed',
+                    $transmissionContext
+                );
+
+                throw $e;
             }
-        } catch (Exception $e) {
-            $this->logger->error(
-                "An error occurred while transmitting $fileName to TurnTo. Error: ",
-                [
-                    'exception' => $e,
-                    'response' => $responseContents
-                ]
-            );
-            throw $e;
         }
+    }
+
+    /**
+     * Backoff in microseconds for a retry attempt.
+     * attempt value starts at 1.
+     *
+     * @param int $attempt
+     * @return int
+     */
+    protected function getRetryDelayMicroseconds(int $attempt): int
+    {
+        return self::TRANSMISSION_RETRY_DELAY_MICROSECONDS * (1 << ($attempt - 1));
     }
 }

--- a/Service/GoogleFeed/Client.php
+++ b/Service/GoogleFeed/Client.php
@@ -10,10 +10,11 @@ namespace TurnTo\SocialCommerce\Service\GoogleFeed;
 use Exception;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\RequestOptions;
+use SimpleXMLElement;
 use TurnTo\SocialCommerce\Api\FeedClient;
 use TurnTo\SocialCommerce\Model\Config;
 use TurnTo\SocialCommerce\Logger\Monolog;
-use TurnTo\SocialCommerce\Model\Export\Catalog;
+use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
 use TurnTo\SocialCommerce\Model\File;
 
 class Client implements FeedClient
@@ -58,9 +59,14 @@ class Client implements FeedClient
     {
         $responseContents = 'win';
         try {
-            if ($feedStyle === Catalog::FEED_STYLE) {
-                $feedData = $feedData->asXML();
-                $path = "turnto/google-product_storecode_{$storeCode}.xml";
+            if ($feedStyle === FeedFormat::GOOGLE_PRODUCT) {
+                if ($feedData instanceof SimpleXMLElement) {
+                    $feedData = $feedData->asXML();
+                }
+                $path = "turnto/google-product_storecode_$storeCode.xml";
+                $this->file->writeFile($path, $feedData);
+            } elseif ($feedStyle === FeedFormat::COMMERCE) {
+                $path = "turnto/commerce-product_storecode_$storeCode.tsv";
                 $this->file->writeFile($path, $feedData);
             }
 
@@ -87,8 +93,11 @@ class Client implements FeedClient
             ]);
 
             $responseContents = $response->getBody()->getContents();
-            if ($feedStyle === Catalog::FEED_STYLE) {
+            if ($feedStyle === FeedFormat::GOOGLE_PRODUCT) {
                 $path = "turnto/google-product_storecode_{$storeCode}_request.xml";
+                $this->file->writeFile($path, $responseContents);
+            } elseif ($feedStyle === FeedFormat::COMMERCE) {
+                $path = "turnto/commerce-product_storecode_{$storeCode}_request.txt";
                 $this->file->writeFile($path, $responseContents);
             }
 

--- a/Test/Unit/Model/Export/CatalogTest.php
+++ b/Test/Unit/Model/Export/CatalogTest.php
@@ -255,11 +255,10 @@ class CatalogTest extends TestCase
         $this->collectionFactory->method('create')->willReturn($this->createProductCollection([$product]));
 
         $this->exportProduct->expects($this->once())->method('preloadRewriteUrls')->with($storeId, [1]);
-        $this->feedClient->expects($this->exactly(3))
+        $this->feedClient->expects($this->once())
             ->method('transmitFeedFile')
             ->willThrowException(new Exception('transmit failed'));
         $this->logger->expects($this->atLeastOnce())->method('error');
-        $this->logger->expects($this->atLeastOnce())->method('warning');
         $this->emulation->expects($this->once())
             ->method('startEnvironmentEmulation')
             ->with($storeId, Area::AREA_FRONTEND, true);
@@ -330,7 +329,7 @@ class CatalogTest extends TestCase
         $this->catalog->cronUploadFeed();
     }
 
-    public function testCronUploadFeedRetriesTransmitThenSucceeds()
+    public function testCronUploadFeedTransmitsFeedFileOnce()
     {
         $storeId = 1;
         $store = $this->createStore($storeId);
@@ -353,13 +352,9 @@ class CatalogTest extends TestCase
         $this->collectionFactory->method('create')->willReturn($this->createProductCollection([$product]));
 
         $this->exportProduct->expects($this->once())->method('preloadRewriteUrls')->with($storeId, [1]);
-        $this->feedClient->expects($this->exactly(2))
+        $this->feedClient->expects($this->once())
             ->method('transmitFeedFile')
-            ->willReturnOnConsecutiveCalls(
-                $this->throwException(new Exception('transient fail')),
-                $this->returnValue(null)
-            );
-        $this->logger->expects($this->once())->method('warning');
+            ->willReturn(null);
         $this->logger->expects($this->never())->method('error');
 
         $this->catalog = $this->createCatalog();

--- a/Test/Unit/Model/Export/CatalogTest.php
+++ b/Test/Unit/Model/Export/CatalogTest.php
@@ -25,6 +25,7 @@ use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
 use TurnTo\SocialCommerce\Model\Config\Gtin;
 use TurnTo\SocialCommerce\Logger\Monolog;
 use TurnTo\SocialCommerce\Model\Export\Catalog;
+use TurnTo\SocialCommerce\Model\Export\CategoryPathResolver;
 use TurnTo\SocialCommerce\Model\Export\Product;
 use TurnTo\SocialCommerce\Service\Feed\FeedGeneratorFactory;
 
@@ -94,6 +95,10 @@ class CatalogTest extends TestCase
      * @var Product
      */
     protected $exportProduct;
+    /**
+     * @var CategoryPathResolver
+     */
+    protected $categoryPathResolver;
 
     protected function setUp(): void
     {
@@ -107,6 +112,7 @@ class CatalogTest extends TestCase
         $this->feedGeneratorFactory = $this->createMock(FeedGeneratorFactory::class);
         $this->resourceConnection = $this->createMock(ResourceConnection::class);
         $this->exportProduct = $this->createMock(Product::class);
+        $this->categoryPathResolver = $this->createMock(CategoryPathResolver::class);
 
         $this->configValues = [
             ConfigModel::PRODUCT_ENABLE_AUTOMATIC_SUBMISSION => true,
@@ -144,7 +150,8 @@ class CatalogTest extends TestCase
             $this->logger,
             $this->feedGeneratorFactory,
             $this->resourceConnection,
-            $this->exportProduct
+            $this->exportProduct,
+            $this->categoryPathResolver
         );
     }
 
@@ -160,7 +167,8 @@ class CatalogTest extends TestCase
             $this->logger,
             $this->feedGeneratorFactory,
             $this->resourceConnection,
-            $this->exportProduct
+            $this->exportProduct,
+            $this->categoryPathResolver
         );
     }
 
@@ -206,7 +214,7 @@ class CatalogTest extends TestCase
 
         $generator = $this->createMock(FeedGeneratorInterface::class);
         $generator->expects($this->once())->method('getFeedStyle')->willReturn(FeedFormat::COMMERCE);
-        $generator->expects($this->once())->method('beginFeed')->with($store)->willReturn(null);
+        $generator->expects($this->never())->method('beginFeed');
         $generator->expects($this->once())->method('addProduct')->willReturn(false);
         $generator->expects($this->never())->method('finishFeed');
         $this->feedGeneratorFactory->method('create')->with(FeedFormat::COMMERCE)->willReturn($generator);
@@ -219,6 +227,7 @@ class CatalogTest extends TestCase
         $this->collectionFactory->method('create')->willReturn($this->createProductCollection([$product]));
 
         $this->exportProduct->expects($this->once())->method('preloadRewriteUrls')->with($storeId, [1]);
+        $this->categoryPathResolver->expects($this->once())->method('preloadCategoryPaths')->with($storeId, [1]);
         $this->feedClient->expects($this->never())->method('transmitFeedFile');
         $this->logger->expects($this->never())->method('error');
         $this->emulation->expects($this->once())
@@ -255,6 +264,7 @@ class CatalogTest extends TestCase
         $this->collectionFactory->method('create')->willReturn($this->createProductCollection([$product]));
 
         $this->exportProduct->expects($this->once())->method('preloadRewriteUrls')->with($storeId, [1]);
+        $this->categoryPathResolver->expects($this->once())->method('preloadCategoryPaths')->with($storeId, [1]);
         $this->feedClient->expects($this->once())
             ->method('transmitFeedFile')
             ->willThrowException(new Exception('transmit failed'));
@@ -352,6 +362,7 @@ class CatalogTest extends TestCase
         $this->collectionFactory->method('create')->willReturn($this->createProductCollection([$product]));
 
         $this->exportProduct->expects($this->once())->method('preloadRewriteUrls')->with($storeId, [1]);
+        $this->categoryPathResolver->expects($this->once())->method('preloadCategoryPaths')->with($storeId, [1]);
         $this->feedClient->expects($this->once())
             ->method('transmitFeedFile')
             ->willReturn(null);

--- a/Test/Unit/Model/Export/CatalogTest.php
+++ b/Test/Unit/Model/Export/CatalogTest.php
@@ -7,13 +7,21 @@ declare(strict_types=1);
 
 namespace TurnTo\SocialCommerce\Test\Unit\Model\Export;
 
+use Exception;
+use ArrayIterator;
+use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Framework\App\Area;
 use Magento\Store\Model\App\Emulation;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Store\Api\Data\StoreInterface;
 use Magento\Framework\App\ResourceConnection;
 use PHPUnit\Framework\TestCase;
 use TurnTo\SocialCommerce\Api\FeedClient;
+use TurnTo\SocialCommerce\Api\FeedGeneratorInterface;
 use TurnTo\SocialCommerce\Model\Config as ConfigModel;
+use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
 use TurnTo\SocialCommerce\Model\Config\Gtin;
 use TurnTo\SocialCommerce\Logger\Monolog;
 use TurnTo\SocialCommerce\Model\Export\Catalog;
@@ -26,36 +34,335 @@ class CatalogTest extends TestCase
      * @var Catalog
      */
     protected $catalog;
+    /**
+     * @var ConfigModel
+     */
+    protected $config;
+    /**
+     * @var Gtin
+     */
+    protected $gtin;
+    /**
+     * @var StoreManagerInterface
+     */
+    protected $storeManager;
+    /**
+     * @var array
+     */
+    protected $configValues = [];
+    /**
+     * @var string
+     */
+    protected $feedFormat = FeedFormat::COMMERCE;
+    /**
+     * @var string
+     */
+    protected $siteKey = 'site-key';
+    /**
+     * @var string
+     */
+    protected $authorizationKey = 'auth-key';
+    /**
+     * @var bool
+     */
+    protected $useChildSku = false;
+    /**
+     * @var CollectionFactory
+     */
+    protected $collectionFactory;
+    /**
+     * @var FeedClient
+     */
+    protected $feedClient;
+    /**
+     * @var Emulation
+     */
+    protected $emulation;
+    /**
+     * @var Monolog
+     */
+    protected $logger;
+    /**
+     * @var FeedGeneratorFactory
+     */
+    protected $feedGeneratorFactory;
+    /**
+     * @var ResourceConnection
+     */
+    protected $resourceConnection;
+    /**
+     * @var Product
+     */
+    protected $exportProduct;
 
     protected function setUp(): void
     {
-        $config = $this->createMock(ConfigModel::class);
-        $gtin = $this->createMock(Gtin::class);
-        $storeManager = $this->createMock(StoreManagerInterface::class);
-        $collectionFactory = $this->createMock(CollectionFactory::class);
-        $feedClient = $this->createMock(FeedClient::class);
-        $emulation = $this->createMock(Emulation::class);
-        $logger = $this->createMock(Monolog::class);
-        $feedGeneratorFactory = $this->createMock(FeedGeneratorFactory::class);
-        $resourceConnection = $this->createMock(ResourceConnection::class);
-        $exportProduct = $this->createMock(Product::class);
+        $this->config = $this->createMock(ConfigModel::class);
+        $this->gtin = $this->createMock(Gtin::class);
+        $this->storeManager = $this->createMock(StoreManagerInterface::class);
+        $this->collectionFactory = $this->createMock(CollectionFactory::class);
+        $this->feedClient = $this->createMock(FeedClient::class);
+        $this->emulation = $this->createMock(Emulation::class);
+        $this->logger = $this->createMock(Monolog::class);
+        $this->feedGeneratorFactory = $this->createMock(FeedGeneratorFactory::class);
+        $this->resourceConnection = $this->createMock(ResourceConnection::class);
+        $this->exportProduct = $this->createMock(Product::class);
+
+        $this->configValues = [
+            ConfigModel::PRODUCT_ENABLE_AUTOMATIC_SUBMISSION => true,
+            ConfigModel::PRODUCT_FEED_SUBMISSION_URL => 'https://feed.test/upload'
+        ];
+
+        $this->config->method('getConfigValue')->willReturnCallback(
+            function ($path, $scopeCode = null) {
+                return $this->configValues[$path] ?? null;
+            }
+        );
+        $this->config->method('getFeedFormat')->willReturnCallback(function ($storeId = null) {
+            return $this->feedFormat;
+        });
+        $this->config->method('getSiteKey')->willReturnCallback(function ($storeId = null) {
+            return $this->siteKey;
+        });
+        $this->config->method('getAuthorizationKey')->willReturnCallback(function ($storeId = null) {
+            return $this->authorizationKey;
+        });
+        $this->config->method('getUseChildSku')->willReturnCallback(function ($storeId = null) {
+            return $this->useChildSku;
+        });
+        $this->config->method('getIsEnabled')->willReturn(true);
+
+        $this->gtin->method('getGtinAttributesMap')->willReturn([]);
 
         $this->catalog = new Catalog(
-            $config,
-            $gtin,
-            $storeManager,
-            $collectionFactory,
-            $feedClient,
-            $emulation,
-            $logger,
-            $feedGeneratorFactory,
-            $resourceConnection,
-            $exportProduct
+            $this->config,
+            $this->gtin,
+            $this->storeManager,
+            $this->collectionFactory,
+            $this->feedClient,
+            $this->emulation,
+            $this->logger,
+            $this->feedGeneratorFactory,
+            $this->resourceConnection,
+            $this->exportProduct
         );
+    }
+
+    protected function createCatalog()
+    {
+        return new Catalog(
+            $this->config,
+            $this->gtin,
+            $this->storeManager,
+            $this->collectionFactory,
+            $this->feedClient,
+            $this->emulation,
+            $this->logger,
+            $this->feedGeneratorFactory,
+            $this->resourceConnection,
+            $this->exportProduct
+        );
+    }
+
+    protected function createProductCollection(array $products, int $totalPages = 1)
+    {
+        $collection = $this->createMock(Collection::class);
+        $collection->method('setStoreId')->willReturnSelf();
+        $collection->method('addAttributeToSelect')->willReturnSelf();
+        $collection->method('addUrlRewrite')->willReturnSelf();
+        $collection->method('setOrder')->willReturnSelf();
+        $collection->method('setPage')->willReturnSelf();
+        $collection->method('joinField')->willReturnSelf();
+        $collection->method('addStoreFilter')->willReturnSelf();
+        $collection->method('addFieldToFilter')->willReturnSelf();
+        $collection->method('getIterator')->willReturn(new ArrayIterator($products));
+        $collection->method('clear')->willReturnSelf();
+        $collection->method('getLastPageNumber')->willReturn($totalPages);
+
+        return $collection;
+    }
+
+    protected function createStore(int $storeId = 1, string $storeCode = 'default')
+    {
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('getId')->willReturn($storeId);
+        $store->method('getCode')->willReturn($storeCode);
+        return $store;
     }
 
     public function testIsCatalogClass()
     {
         $this->assertInstanceOf(Catalog::class, $this->catalog);
+    }
+
+    public function testCronUploadFeedDoesNotTransmitEmptyBatchWhenNoProductsAreAdded()
+    {
+        $storeId = 1;
+        $store = $this->createStore($storeId);
+
+        $this->storeManager->method('getStores')->willReturn([$store]);
+
+        $this->configValues[ConfigModel::PRODUCT_FEED_SUBMISSION_URL] = 'https://feed.test/upload';
+
+        $generator = $this->createMock(FeedGeneratorInterface::class);
+        $generator->expects($this->once())->method('getFeedStyle')->willReturn(FeedFormat::COMMERCE);
+        $generator->expects($this->once())->method('beginFeed')->with($store)->willReturn(null);
+        $generator->expects($this->once())->method('addProduct')->willReturn(false);
+        $generator->expects($this->never())->method('finishFeed');
+        $this->feedGeneratorFactory->method('create')->with(FeedFormat::COMMERCE)->willReturn($generator);
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getId')->willReturn(1);
+        $product->method('getSku')->willReturn('SKU1');
+        $product->method('getTypeId')->willReturn('simple');
+
+        $this->collectionFactory->method('create')->willReturn($this->createProductCollection([$product]));
+
+        $this->exportProduct->expects($this->once())->method('preloadRewriteUrls')->with($storeId, [1]);
+        $this->feedClient->expects($this->never())->method('transmitFeedFile');
+        $this->logger->expects($this->never())->method('error');
+        $this->emulation->expects($this->once())
+            ->method('startEnvironmentEmulation')
+            ->with($storeId, Area::AREA_FRONTEND, true);
+        $this->emulation->expects($this->once())->method('stopEnvironmentEmulation');
+
+        $this->catalog = $this->createCatalog();
+        $this->catalog->cronUploadFeed();
+    }
+
+    public function testCronUploadFeedLogsAndStopsWhenTransmitFails()
+    {
+        $storeId = 1;
+        $store = $this->createStore($storeId);
+
+        $this->storeManager->method('getStores')->willReturn([$store]);
+
+        $this->configValues[ConfigModel::PRODUCT_FEED_SUBMISSION_URL] = 'https://feed.test/upload';
+        $this->gtin->method('getGtinAttributesMap')->willReturn([]);
+
+        $generator = $this->createMock(FeedGeneratorInterface::class);
+        $generator->method('getFeedStyle')->willReturn(FeedFormat::COMMERCE);
+        $generator->expects($this->once())->method('beginFeed')->with($store)->willReturn(null);
+        $generator->expects($this->once())->method('addProduct')->willReturn(true);
+        $generator->method('finishFeed')->willReturn('feed');
+        $this->feedGeneratorFactory->method('create')->with(FeedFormat::COMMERCE)->willReturn($generator);
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getId')->willReturn(1);
+        $product->method('getSku')->willReturn('SKU1');
+        $product->method('getTypeId')->willReturn('simple');
+
+        $this->collectionFactory->method('create')->willReturn($this->createProductCollection([$product]));
+
+        $this->exportProduct->expects($this->once())->method('preloadRewriteUrls')->with($storeId, [1]);
+        $this->feedClient->expects($this->exactly(3))
+            ->method('transmitFeedFile')
+            ->willThrowException(new Exception('transmit failed'));
+        $this->logger->expects($this->atLeastOnce())->method('error');
+        $this->logger->expects($this->atLeastOnce())->method('warning');
+        $this->emulation->expects($this->once())
+            ->method('startEnvironmentEmulation')
+            ->with($storeId, Area::AREA_FRONTEND, true);
+        $this->emulation->expects($this->once())->method('stopEnvironmentEmulation');
+
+        $this->catalog = $this->createCatalog();
+        $this->catalog->cronUploadFeed();
+    }
+
+    public function testGetProductsAddsDeterministicOrder()
+    {
+        $productCollection = $this->createProductCollection([], 3);
+        $productCollection->expects($this->once())->method('setOrder')->with('entity_id', 'ASC');
+        $this->collectionFactory->method('create')->willReturn($productCollection);
+
+        $this->catalog = $this->createCatalog();
+        $result = $this->catalog->getProducts(1, 1, 500);
+
+        $this->assertSame($productCollection, $result);
+    }
+
+    public function testGetProductsReturnsFalseWhenPageExceedsLastPage()
+    {
+        $productCollection = $this->createProductCollection([], 1);
+        $this->collectionFactory->method('create')->willReturn($productCollection);
+
+        $this->catalog = $this->createCatalog();
+        $result = $this->catalog->getProducts(1, 3, 500);
+
+        $this->assertFalse($result);
+    }
+
+    public function testCronUploadFeedSkipsStoreIfFeedFormatInvalid()
+    {
+        $storeId = 1;
+        $store = $this->createStore($storeId);
+
+        $this->storeManager->method('getStores')->willReturn([$store]);
+        $this->configValues[ConfigModel::PRODUCT_FEED_SUBMISSION_URL] = 'https://feed.test/upload';
+        $this->feedFormat = 'invalid_format';
+
+        $this->feedGeneratorFactory->expects($this->never())->method('create');
+        $this->collectionFactory->expects($this->never())->method('create');
+        $this->feedClient->expects($this->never())->method('transmitFeedFile');
+        $this->emulation->expects($this->never())->method('startEnvironmentEmulation');
+        $this->emulation->expects($this->never())->method('stopEnvironmentEmulation');
+        $this->logger->expects($this->once())->method('error');
+
+        $this->catalog->cronUploadFeed();
+    }
+
+    public function testCronUploadFeedSkipsStoreIfCredentialsIncomplete()
+    {
+        $storeId = 1;
+        $store = $this->createStore($storeId);
+
+        $this->storeManager->method('getStores')->willReturn([$store]);
+        $this->configValues[ConfigModel::PRODUCT_FEED_SUBMISSION_URL] = 'https://feed.test/upload';
+        $this->siteKey = '';
+
+        $this->feedGeneratorFactory->expects($this->never())->method('create');
+        $this->collectionFactory->expects($this->never())->method('create');
+        $this->feedClient->expects($this->never())->method('transmitFeedFile');
+        $this->logger->expects($this->once())->method('error');
+        $this->emulation->expects($this->never())->method('startEnvironmentEmulation');
+        $this->emulation->expects($this->never())->method('stopEnvironmentEmulation');
+
+        $this->catalog->cronUploadFeed();
+    }
+
+    public function testCronUploadFeedRetriesTransmitThenSucceeds()
+    {
+        $storeId = 1;
+        $store = $this->createStore($storeId);
+
+        $this->storeManager->method('getStores')->willReturn([$store]);
+        $this->configValues[ConfigModel::PRODUCT_FEED_SUBMISSION_URL] = 'https://feed.test/upload';
+
+        $generator = $this->createMock(FeedGeneratorInterface::class);
+        $generator->method('getFeedStyle')->willReturn(FeedFormat::COMMERCE);
+        $generator->expects($this->once())->method('beginFeed')->with($store)->willReturn(null);
+        $generator->expects($this->once())->method('addProduct')->willReturn(true);
+        $generator->method('finishFeed')->willReturn('feed');
+        $this->feedGeneratorFactory->method('create')->with(FeedFormat::COMMERCE)->willReturn($generator);
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getId')->willReturn(1);
+        $product->method('getSku')->willReturn('SKU1');
+        $product->method('getTypeId')->willReturn('simple');
+
+        $this->collectionFactory->method('create')->willReturn($this->createProductCollection([$product]));
+
+        $this->exportProduct->expects($this->once())->method('preloadRewriteUrls')->with($storeId, [1]);
+        $this->feedClient->expects($this->exactly(2))
+            ->method('transmitFeedFile')
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new Exception('transient fail')),
+                $this->returnValue(null)
+            );
+        $this->logger->expects($this->once())->method('warning');
+        $this->logger->expects($this->never())->method('error');
+
+        $this->catalog = $this->createCatalog();
+        $this->catalog->cronUploadFeed();
     }
 }

--- a/Test/Unit/Model/Export/CatalogTest.php
+++ b/Test/Unit/Model/Export/CatalogTest.php
@@ -214,9 +214,25 @@ class CatalogTest extends TestCase
 
         $generator = $this->createMock(FeedGeneratorInterface::class);
         $generator->expects($this->once())->method('getFeedStyle')->willReturn(FeedFormat::COMMERCE);
-        $generator->expects($this->never())->method('beginFeed');
+        $isFeedOpen = false;
+        $generator->method('isFeedOpen')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                return $isFeedOpen;
+            }
+        );
+        $generator->expects($this->once())->method('beginFeed')->with($store)->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = true;
+                return null;
+            }
+        );
         $generator->expects($this->once())->method('addProduct')->willReturn(false);
-        $generator->expects($this->never())->method('finishFeed');
+        $generator->expects($this->once())->method('finishFeed')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = false;
+                return 'feed';
+            }
+        );
         $this->feedGeneratorFactory->method('create')->with(FeedFormat::COMMERCE)->willReturn($generator);
 
         $product = $this->createMock(CatalogProduct::class);
@@ -239,6 +255,121 @@ class CatalogTest extends TestCase
         $this->catalog->cronUploadFeed();
     }
 
+    public function testCronUploadFeedStartsFeedBeforeProcessingFirstProduct()
+    {
+        $storeId = 1;
+        $store = $this->createStore($storeId);
+
+        $this->storeManager->method('getStores')->willReturn([$store]);
+
+        $this->configValues[ConfigModel::PRODUCT_FEED_SUBMISSION_URL] = 'https://feed.test/upload';
+
+        $callOrder = [];
+
+        $generator = $this->createMock(FeedGeneratorInterface::class);
+        $generator->method('getFeedStyle')->willReturn(FeedFormat::COMMERCE);
+        $isFeedOpen = false;
+        $generator->method('isFeedOpen')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                return $isFeedOpen;
+            }
+        );
+        $generator->expects($this->once())->method('beginFeed')->with($store)->willReturnCallback(
+            function () use (&$callOrder, &$isFeedOpen) {
+                $isFeedOpen = true;
+                $callOrder[] = 'beginFeed';
+                return null;
+            }
+        );
+        $generator->expects($this->atLeastOnce())->method('addProduct')->willReturnCallback(
+            function () use (&$callOrder) {
+                $callOrder[] = 'addProduct';
+                return false;
+            }
+        );
+        $generator->expects($this->once())->method('finishFeed')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = false;
+                return 'feed';
+            }
+        );
+        $this->feedGeneratorFactory->method('create')->with(FeedFormat::COMMERCE)->willReturn($generator);
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getId')->willReturn(1);
+        $product->method('getSku')->willReturn('SKU1');
+        $product->method('getTypeId')->willReturn('simple');
+
+        $this->collectionFactory->method('create')->willReturn($this->createProductCollection([$product]));
+
+        $this->exportProduct->expects($this->once())->method('preloadRewriteUrls')->with($storeId, [1]);
+        $this->categoryPathResolver->expects($this->once())->method('preloadCategoryPaths')->with($storeId, [1]);
+        $this->feedClient->expects($this->never())->method('transmitFeedFile');
+        $this->logger->expects($this->never())->method('error');
+        $this->emulation->expects($this->once())
+            ->method('startEnvironmentEmulation')
+            ->with($storeId, Area::AREA_FRONTEND, true);
+        $this->emulation->expects($this->once())->method('stopEnvironmentEmulation');
+
+        $this->catalog = $this->createCatalog();
+        $this->catalog->cronUploadFeed();
+
+        $this->assertSame('beginFeed', $callOrder[0]);
+        $this->assertEquals('addProduct', $callOrder[1]);
+    }
+
+    public function testCronUploadFeedFinishesFeedWhenProductWriteFails()
+    {
+        $storeId = 1;
+        $store = $this->createStore($storeId);
+
+        $this->storeManager->method('getStores')->willReturn([$store]);
+
+        $this->configValues[ConfigModel::PRODUCT_FEED_SUBMISSION_URL] = 'https://feed.test/upload';
+
+        $generator = $this->createMock(FeedGeneratorInterface::class);
+        $generator->method('getFeedStyle')->willReturn(FeedFormat::COMMERCE);
+        $isFeedOpen = false;
+        $generator->method('isFeedOpen')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                return $isFeedOpen;
+            }
+        );
+        $generator->expects($this->once())->method('beginFeed')->with($store)->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = true;
+                return null;
+            }
+        );
+        $generator->expects($this->once())->method('addProduct')->willThrowException(new Exception('add failed'));
+        $generator->expects($this->once())->method('finishFeed')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = false;
+                return 'feed';
+            }
+        );
+        $this->feedGeneratorFactory->method('create')->with(FeedFormat::COMMERCE)->willReturn($generator);
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getId')->willReturn(1);
+        $product->method('getSku')->willReturn('SKU1');
+        $product->method('getTypeId')->willReturn('simple');
+
+        $this->collectionFactory->method('create')->willReturn($this->createProductCollection([$product]));
+
+        $this->exportProduct->expects($this->once())->method('preloadRewriteUrls')->with($storeId, [1]);
+        $this->categoryPathResolver->expects($this->once())->method('preloadCategoryPaths')->with($storeId, [1]);
+        $this->feedClient->expects($this->never())->method('transmitFeedFile');
+        $this->logger->expects($this->atLeastOnce())->method('error');
+        $this->emulation->expects($this->once())
+            ->method('startEnvironmentEmulation')
+            ->with($storeId, Area::AREA_FRONTEND, true);
+        $this->emulation->expects($this->once())->method('stopEnvironmentEmulation');
+
+        $this->catalog = $this->createCatalog();
+        $this->catalog->cronUploadFeed();
+    }
+
     public function testCronUploadFeedLogsAndStopsWhenTransmitFails()
     {
         $storeId = 1;
@@ -251,9 +382,25 @@ class CatalogTest extends TestCase
 
         $generator = $this->createMock(FeedGeneratorInterface::class);
         $generator->method('getFeedStyle')->willReturn(FeedFormat::COMMERCE);
-        $generator->expects($this->once())->method('beginFeed')->with($store)->willReturn(null);
+        $isFeedOpen = false;
+        $generator->method('isFeedOpen')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                return $isFeedOpen;
+            }
+        );
+        $generator->expects($this->once())->method('beginFeed')->with($store)->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = true;
+                return null;
+            }
+        );
         $generator->expects($this->once())->method('addProduct')->willReturn(true);
-        $generator->method('finishFeed')->willReturn('feed');
+        $generator->expects($this->once())->method('finishFeed')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = false;
+                return 'feed';
+            }
+        );
         $this->feedGeneratorFactory->method('create')->with(FeedFormat::COMMERCE)->willReturn($generator);
 
         $product = $this->createMock(CatalogProduct::class);
@@ -349,9 +496,25 @@ class CatalogTest extends TestCase
 
         $generator = $this->createMock(FeedGeneratorInterface::class);
         $generator->method('getFeedStyle')->willReturn(FeedFormat::COMMERCE);
-        $generator->expects($this->once())->method('beginFeed')->with($store)->willReturn(null);
+        $isFeedOpen = false;
+        $generator->method('isFeedOpen')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                return $isFeedOpen;
+            }
+        );
+        $generator->expects($this->once())->method('beginFeed')->with($store)->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = true;
+                return null;
+            }
+        );
         $generator->expects($this->once())->method('addProduct')->willReturn(true);
-        $generator->method('finishFeed')->willReturn('feed');
+        $generator->method('finishFeed')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = false;
+                return 'feed';
+            }
+        );
         $this->feedGeneratorFactory->method('create')->with(FeedFormat::COMMERCE)->willReturn($generator);
 
         $product = $this->createMock(CatalogProduct::class);

--- a/Test/Unit/Model/Export/CatalogTest.php
+++ b/Test/Unit/Model/Export/CatalogTest.php
@@ -7,27 +7,18 @@ declare(strict_types=1);
 
 namespace TurnTo\SocialCommerce\Test\Unit\Model\Export;
 
-use Magento\Catalog\Helper\Image;
-use Magento\Catalog\Model\Product as CatalogProduct;
-use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
-use Magento\Directory\Model\Currency;
-use Magento\Framework\Intl\DateTimeFactory;
-use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Store\Model\App\Emulation;
 use Magento\Store\Model\StoreManagerInterface;
-use Magento\Eav\Model\Config as EavConfig;
-use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
-use PHPUnit\Framework\MockObject\Exception;
+use Magento\Framework\App\ResourceConnection;
 use PHPUnit\Framework\TestCase;
-use SimpleXMLElement;
 use TurnTo\SocialCommerce\Api\FeedClient;
 use TurnTo\SocialCommerce\Model\Config as ConfigModel;
 use TurnTo\SocialCommerce\Model\Config\Gtin;
-use TurnTo\SocialCommerce\Model\Product;
 use TurnTo\SocialCommerce\Logger\Monolog;
 use TurnTo\SocialCommerce\Model\Export\Catalog;
-use TurnTo\SocialCommerce\Test\Unit\Model\Export\TestableCatalog;
+use TurnTo\SocialCommerce\Model\Export\Product;
+use TurnTo\SocialCommerce\Service\Feed\FeedGeneratorFactory;
 
 class CatalogTest extends TestCase
 {
@@ -36,192 +27,35 @@ class CatalogTest extends TestCase
      */
     protected $catalog;
 
-    /**
-     * @var EavConfig
-     */
-    protected $eavConfig;
-
-    /**
-     * Is called before running a test
-     * @throws Exception
-     */
     protected function setUp(): void
     {
         $config = $this->createMock(ConfigModel::class);
         $gtin = $this->createMock(Gtin::class);
         $storeManager = $this->createMock(StoreManagerInterface::class);
         $collectionFactory = $this->createMock(CollectionFactory::class);
-        $dateTimeFactory = $this->createMock(DateTimeFactory::class);
-        $imageHelper = $this->createMock(Image::class);
-        $turntoProduct = $this->createMock(Product::class);
-        $this->eavConfig = $this->createMock(EavConfig::class);
         $feedClient = $this->createMock(FeedClient::class);
         $emulation = $this->createMock(Emulation::class);
-        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
         $logger = $this->createMock(Monolog::class);
+        $feedGeneratorFactory = $this->createMock(FeedGeneratorFactory::class);
+        $resourceConnection = $this->createMock(ResourceConnection::class);
+        $exportProduct = $this->createMock(Product::class);
 
         $this->catalog = new Catalog(
             $config,
             $gtin,
             $storeManager,
             $collectionFactory,
-            $dateTimeFactory,
-            $imageHelper,
-            $turntoProduct,
-            $this->eavConfig,
             $feedClient,
             $emulation,
-            $priceCurrency,
-            $logger
+            $logger,
+            $feedGeneratorFactory,
+            $resourceConnection,
+            $exportProduct
         );
     }
 
-    public function testIsCatalogClass(){
+    public function testIsCatalogClass()
+    {
         $this->assertInstanceOf(Catalog::class, $this->catalog);
-    }
-
-    public function testGetGtinValueReturnsLabelForSelectAttribute()
-    {
-        $product = $this->createMock(CatalogProduct::class);
-        $attribute = $this->getMockBuilder(AbstractAttribute::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['usesSource'])
-            ->getMock();
-        $attribute->method('usesSource')->willReturn(true);
-        $this->eavConfig->method('getAttribute')->willReturn($attribute);
-
-        $product->method('getAttributeText')
-            ->with('upc')
-            ->willReturn('UPC Label');
-
-        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
-        $this->assertSame('UPC Label', $this->catalog->getGtinValue($product, $gtinMap));
-    }
-
-    public function testGetGtinValueReturnsCommaSeparatedForMultiselect()
-    {
-        $product = $this->createMock(CatalogProduct::class);
-        $attribute = $this->getMockBuilder(AbstractAttribute::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['usesSource'])
-            ->getMock();
-        $attribute->method('usesSource')->willReturn(true);
-        $this->eavConfig->method('getAttribute')->willReturn($attribute);
-
-        $product->method('getAttributeText')
-            ->with('upc')
-            ->willReturn(['Red', 'Blue']);
-
-        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
-        $this->assertSame('Red, Blue', $this->catalog->getGtinValue($product, $gtinMap));
-    }
-
-    public function testGetGtinValueReturnsRawForNonSourceAttribute()
-    {
-        $product = $this->createMock(CatalogProduct::class);
-        $attribute = $this->getMockBuilder(AbstractAttribute::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['usesSource'])
-            ->getMock();
-        $attribute->method('usesSource')->willReturn(false);
-        $this->eavConfig->method('getAttribute')->willReturn($attribute);
-
-        $product->method('getData')
-            ->with('upc')
-            ->willReturn('12345');
-
-        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
-        $this->assertSame('12345', $this->catalog->getGtinValue($product, $gtinMap));
-    }
-
-    public function testGetGtinValueReturnsImplodedForArrayData()
-    {
-        $product = $this->createMock(CatalogProduct::class);
-        $attribute = $this->getMockBuilder(AbstractAttribute::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['usesSource'])
-            ->getMock();
-        $attribute->method('usesSource')->willReturn(false);
-        $this->eavConfig->method('getAttribute')->willReturn($attribute);
-
-        $product->method('getData')
-            ->with('upc')
-            ->willReturn([1, 2]);
-
-        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
-        $this->assertSame('1, 2', $this->catalog->getGtinValue($product, $gtinMap));
-    }
-
-    public function testAddProductToAtomFeedWritesConvertedFinalPriceWithCurrency()
-    {
-        $config = $this->createMock(ConfigModel::class);
-        $gtin = $this->createMock(Gtin::class);
-        $storeManager = $this->createMock(StoreManagerInterface::class);
-        $collectionFactory = $this->createMock(CollectionFactory::class);
-        $dateTimeFactory = $this->createMock(DateTimeFactory::class);
-        $imageHelper = $this->createMock(Image::class);
-        $turntoProduct = $this->createMock(Product::class);
-        $feedClient = $this->createMock(FeedClient::class);
-        $emulation = $this->createMock(Emulation::class);
-        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
-        $logger = $this->createMock(Monolog::class);
-
-        // Ensure safe SKU encoding passthrough
-        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
-            return (string) $value;
-        });
-
-        // Set expectations for currency conversion and currency code retrieval
-        $storeId = 1;
-        $finalPrice = 12.34;
-
-        $priceCurrency
-            ->expects($this->once())
-            ->method('convertAndRound')
-            ->with($finalPrice, $storeId)
-            ->willReturn($finalPrice);
-
-        $currencyMock = $this->createPartialMock(
-            Currency::class,
-            ['getCurrencyCode']
-        );
-        $currencyMock->method('getCurrencyCode')->willReturn('USD');
-        $priceCurrency->method('getCurrency')->with($storeId)->willReturn($currencyMock);
-
-        // Build the catalog instance under test
-        $catalog = new TestableCatalog(
-            $config,
-            $gtin,
-            $storeManager,
-            $collectionFactory,
-            $dateTimeFactory,
-            $imageHelper,
-            $turntoProduct,
-            $this->eavConfig,
-            $feedClient,
-            $emulation,
-            $priceCurrency,
-            $logger
-        );
-
-        // Minimal product stub to satisfy feed requirements
-        $product = $this->createMock(CatalogProduct::class);
-        $product->method('getSku')->willReturn('SKU-1');
-        $product->method('getProductUrl')->willReturn('https://example.com/p');
-        $product->method('getName')->willReturn('Product Name');
-        $product->method('getImage')->willReturn(null); // avoid image helper chain
-        $product->method('getFinalPrice')->willReturn($finalPrice);
-        $product->method('getCustomAttribute')->willReturn(null);
-        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
-
-        $entry = new SimpleXMLElement('<entry />');
-
-        // Execute
-        $catalog->callAddProductToAtomFeed($entry, $product, $storeId, false);
-
-        // Assert price element is present and formatted with currency code
-        $xmlString = $entry->asXML();
-        $this->assertIsString($xmlString);
-        $this->assertStringContainsString('<price>12.34 USD</price>', $xmlString);
     }
 }

--- a/Test/Unit/Service/Feed/CommerceFeedGeneratorTest.php
+++ b/Test/Unit/Service/Feed/CommerceFeedGeneratorTest.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Test\Unit\Service\Feed;
+
+use Magento\Catalog\Helper\Image;
+use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Bundle\Model\Product\Type as BundleType;
+use Magento\Catalog\Model\Product\Type\AbstractType;
+use Magento\GroupedProduct\Model\Product\Type\Grouped as GroupedType;
+use Magento\Directory\Model\Currency;
+use Magento\Eav\Model\Config as EavConfig;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use PHPUnit\Framework\TestCase;
+use TurnTo\SocialCommerce\Model\Config as ConfigModel;
+use TurnTo\SocialCommerce\Model\Config\Gtin;
+use TurnTo\SocialCommerce\Model\Export\Product as ExportProduct;
+use TurnTo\SocialCommerce\Model\Product;
+use TurnTo\SocialCommerce\Logger\Monolog;
+use TurnTo\SocialCommerce\Service\Feed\CommerceFeedGenerator;
+
+/**
+ * Exposes protected feed helpers for unit testing.
+ */
+class TestableCommerceFeedGenerator extends CommerceFeedGenerator
+{
+    /**
+     * @param ConfigModel $config
+     * @param Gtin $gtin
+     * @param Image $imageHelper
+     * @param Product $turntoProduct
+     * @param EavConfig $eavConfig
+     * @param PriceCurrencyInterface $priceCurrency
+     * @param Monolog $logger
+     * @param ExportProduct $exportProduct
+     */
+    public function __construct(
+        ConfigModel $config,
+        Gtin $gtin,
+        Image $imageHelper,
+        Product $turntoProduct,
+        EavConfig $eavConfig,
+        PriceCurrencyInterface $priceCurrency,
+        Monolog $logger,
+        ExportProduct $exportProduct
+    ) {
+        parent::__construct(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $exportProduct
+        );
+    }
+
+    /**
+     * @param CatalogProduct $product
+     * @param int|string|null $storeId
+     * @param bool|CatalogProduct|null $parent
+     * @return string
+     */
+    public function callGenerateProductLine($product, $storeId, $parent)
+    {
+        return $this->generateProductLine($product, $storeId, $parent);
+    }
+
+    /**
+     * @param CatalogProduct $product
+     * @return string
+     */
+    public function callGetMembers($product)
+    {
+        return $this->getMembers($product);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getCategoryTreeString(CatalogProduct $product, $storeId)
+    {
+        return 'Category 1 > Category 2';
+    }
+}
+
+class CommerceFeedGeneratorTest extends TestCase
+{
+    /**
+     * @var TestableCommerceFeedGenerator
+     */
+    protected $generator;
+
+    protected function setUp(): void
+    {
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $eavConfig = $this->createMock(EavConfig::class);
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $logger = $this->createMock(Monolog::class);
+
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return (string) $value;
+        });
+
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.test/p');
+
+        $this->generator = new TestableCommerceFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $exportProduct
+        );
+    }
+
+    public function testGetMembersForBundleProduct()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getTypeId')->willReturn('bundle');
+
+        $typeInstance = $this->createMock(BundleType::class);
+        $typeInstance->method('getOptionsIds')->willReturn([1, 2]);
+
+        $selection1 = $this->createMock(CatalogProduct::class);
+        $selection1->method('getSku')->willReturn('CHILD-1');
+
+        $selection2 = $this->createMock(CatalogProduct::class);
+        $selection2->method('getSku')->willReturn('CHILD-2');
+
+        $typeInstance->method('getSelectionsCollection')->willReturn([$selection1, $selection2]);
+
+        $product->method('getTypeInstance')->willReturn($typeInstance);
+
+        $members = $this->generator->callGetMembers($product);
+        $this->assertEquals('CHILD-1,CHILD-2', $members);
+    }
+
+    public function testGetMembersForGroupedProduct()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getTypeId')->willReturn('grouped');
+
+        $typeInstance = $this->createMock(GroupedType::class);
+
+        $child1 = $this->createMock(CatalogProduct::class);
+        $child1->method('getSku')->willReturn('GROUP-CHILD-1');
+
+        $child2 = $this->createMock(CatalogProduct::class);
+        $child2->method('getSku')->willReturn('GROUP-CHILD-2');
+
+        $typeInstance->method('getAssociatedProducts')->willReturn([$child1, $child2]);
+
+        $product->method('getTypeInstance')->willReturn($typeInstance);
+
+        $members = $this->generator->callGetMembers($product);
+        $this->assertEquals('GROUP-CHILD-1,GROUP-CHILD-2', $members);
+    }
+
+    public function testGenerateProductLine()
+    {
+        $storeId = 1;
+        $finalPrice = 12.34;
+
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $priceCurrency
+            ->method('convertAndRound')
+            ->with($finalPrice, $storeId)
+            ->willReturn($finalPrice);
+
+        $currencyMock = $this->createPartialMock(
+            Currency::class,
+            ['getCurrencyCode']
+        );
+        $currencyMock->method('getCurrencyCode')->willReturn('USD');
+        $priceCurrency->method('getCurrency')->with($storeId)->willReturn($currencyMock);
+
+        // Re-instantiate with mocked priceCurrency to test generateProductLine
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $eavConfig = $this->createMock(EavConfig::class);
+        $logger = $this->createMock(Monolog::class);
+
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return (string) $value;
+        });
+
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.com/p');
+
+        $generator = new TestableCommerceFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $exportProduct
+        );
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('SKU-1');
+        $product->method('getName')->willReturn('Product Name');
+        $product->method('getImage')->willReturn(null);
+        $product->method('getFinalPrice')->willReturn($finalPrice);
+        $product->method('getCustomAttribute')->willReturn(null);
+        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+        $product->method('getTypeId')->willReturn('simple');
+
+        $line = $generator->callGenerateProductLine($product, $storeId, false);
+
+        $expectedCategoryJson = json_encode([
+            ['id' => '10', 'name' => 'Category 1'],
+            ['id' => '20', 'name' => 'Category 2']
+        ]);
+
+        $expectedLine = implode("\t", [
+            'SKU-1',
+            'Product Name',
+            'https://example.com/p',
+            '', // image_url
+            '0', // stock (not in stock / no qty when is_in_stock is false)
+            '1', // active
+            $expectedCategoryJson,
+            '', // virtual_parent_code
+            '', // members
+            '', // brand
+            'USD',
+            '12.34',
+            '', // upc
+            '', // ean
+            ''  // mpn
+        ]);
+
+        $this->assertEquals($expectedLine, $line);
+    }
+}

--- a/Test/Unit/Service/Feed/CommerceFeedGeneratorTest.php
+++ b/Test/Unit/Service/Feed/CommerceFeedGeneratorTest.php
@@ -170,6 +170,103 @@ class CommerceFeedGeneratorTest extends TestCase
         $this->assertEquals('GROUP-CHILD-1,GROUP-CHILD-2', $members);
     }
 
+    public function testGetMembersForBundleProductEncodesSpecialCharacterSku()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getTypeId')->willReturn('bundle');
+
+        $typeInstance = $this->createMock(BundleType::class);
+        $typeInstance->method('getOptionsIds')->willReturn([1, 2]);
+
+        $selection1 = $this->createMock(CatalogProduct::class);
+        $selection1->method('getSku')->willReturn('CHILD/1');
+
+        $selection2 = $this->createMock(CatalogProduct::class);
+        $selection2->method('getSku')->willReturn('CHILD+2');
+
+        $typeInstance->method('getSelectionsCollection')->willReturn([$selection1, $selection2]);
+
+        $product->method('getTypeInstance')->willReturn($typeInstance);
+
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return str_replace(
+                array_keys(Product::TURNTO_CHARACTER_MAPPING),
+                array_values(Product::TURNTO_CHARACTER_MAPPING),
+                (string) $value
+            );
+        });
+        $eavConfig = $this->createMock(EavConfig::class);
+        $logger = $this->createMock(Monolog::class);
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $exportProduct = $this->createMock(ExportProduct::class);
+
+        $generator = new TestableCommerceFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $exportProduct
+        );
+
+        $members = $generator->callGetMembers($product);
+        $this->assertEquals('CHILDFORWARDSLASH1,CHILDPLUS2', $members);
+    }
+
+    public function testGetMembersForGroupedProductEncodesSpecialCharacterSku()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getTypeId')->willReturn('grouped');
+
+        $typeInstance = $this->createMock(GroupedType::class);
+
+        $child1 = $this->createMock(CatalogProduct::class);
+        $child1->method('getSku')->willReturn('GROUP/CHILD#1');
+
+        $child2 = $this->createMock(CatalogProduct::class);
+        $child2->method('getSku')->willReturn('GROUP/CHILD#2');
+
+        $typeInstance->method('getAssociatedProducts')->willReturn([$child1, $child2]);
+
+        $product->method('getTypeInstance')->willReturn($typeInstance);
+
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return str_replace(
+                array_keys(Product::TURNTO_CHARACTER_MAPPING),
+                array_values(Product::TURNTO_CHARACTER_MAPPING),
+                (string) $value
+            );
+        });
+        $eavConfig = $this->createMock(EavConfig::class);
+        $logger = $this->createMock(Monolog::class);
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $exportProduct = $this->createMock(ExportProduct::class);
+
+        $generator = new TestableCommerceFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $exportProduct
+        );
+
+        $members = $generator->callGetMembers($product);
+        $this->assertEquals('GROUPFORWARDSLASHCHILDHASH1,GROUPFORWARDSLASHCHILDHASH2', $members);
+    }
+
     public function testGenerateProductLine()
     {
         $storeId = 1;
@@ -239,6 +336,193 @@ class CommerceFeedGeneratorTest extends TestCase
             '1', // active
             $expectedCategoryJson,
             '', // virtual_parent_code
+            '', // members
+            '', // brand
+            'USD',
+            '12.34',
+            '', // upc
+            '', // ean
+            ''  // mpn
+        ]);
+
+        $this->assertEquals($expectedLine, $line);
+    }
+
+    public function testGenerateProductLineSkipsVirtualParentForSpecialCharacterSku()
+    {
+        $storeId = 1;
+        $finalPrice = 12.34;
+
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $priceCurrency
+            ->method('convertAndRound')
+            ->with($finalPrice, $storeId)
+            ->willReturn($finalPrice);
+
+        $currencyMock = $this->createPartialMock(
+            Currency::class,
+            ['getCurrencyCode']
+        );
+        $currencyMock->method('getCurrencyCode')->willReturn('USD');
+        $priceCurrency->method('getCurrency')->with($storeId)->willReturn($currencyMock);
+
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return str_replace(
+                array_keys(Product::TURNTO_CHARACTER_MAPPING),
+                array_values(Product::TURNTO_CHARACTER_MAPPING),
+                (string) $value
+            );
+        });
+        $eavConfig = $this->createMock(EavConfig::class);
+        $logger = $this->createMock(Monolog::class);
+
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.com/p');
+
+        $generator = new TestableCommerceFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $exportProduct
+        );
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('SKU/1');
+        $product->method('getName')->willReturn('Product Name');
+        $product->method('getImage')->willReturn(null);
+        $product->method('getFinalPrice')->willReturn($finalPrice);
+        $product->method('getCustomAttribute')->willReturn(null);
+        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+        $product->method('getTypeId')->willReturn('simple');
+        $product->method('getData')->willReturnCallback(function ($value) {
+            if ($value === 'is_in_stock') {
+                return 1;
+            }
+            if ($value === 'qty') {
+                return 2;
+            }
+            return null;
+        });
+
+        $line = $generator->callGenerateProductLine($product, $storeId, false);
+
+        $expectedCategoryJson = json_encode([
+            ['id' => '10', 'name' => 'Category 1'],
+            ['id' => '20', 'name' => 'Category 2']
+        ]);
+
+        $expectedLine = implode("\t", [
+            'SKUFORWARDSLASH1',
+            'Product Name',
+            'https://example.com/p',
+            '', // image_url
+            '2', // stock (in stock)
+            '1', // active
+            $expectedCategoryJson,
+            '', // virtual_parent_code
+            '', // members
+            '', // brand
+            'USD',
+            '12.34',
+            '', // upc
+            '', // ean
+            ''  // mpn
+        ]);
+
+        $this->assertEquals($expectedLine, $line);
+    }
+
+    public function testGenerateProductLineEncodesVirtualParentFromParentSku()
+    {
+        $storeId = 1;
+        $finalPrice = 12.34;
+
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $priceCurrency
+            ->method('convertAndRound')
+            ->with($finalPrice, $storeId)
+            ->willReturn($finalPrice);
+
+        $currencyMock = $this->createPartialMock(
+            Currency::class,
+            ['getCurrencyCode']
+        );
+        $currencyMock->method('getCurrencyCode')->willReturn('USD');
+        $priceCurrency->method('getCurrency')->with($storeId)->willReturn($currencyMock);
+
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return str_replace(
+                array_keys(Product::TURNTO_CHARACTER_MAPPING),
+                array_values(Product::TURNTO_CHARACTER_MAPPING),
+                (string) $value
+            );
+        });
+        $eavConfig = $this->createMock(EavConfig::class);
+        $logger = $this->createMock(Monolog::class);
+
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.com/p');
+
+        $generator = new TestableCommerceFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $exportProduct
+        );
+
+        $parent = $this->createMock(CatalogProduct::class);
+        $parent->method('getSku')->willReturn('PARENT/1');
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('CHILD+1');
+        $product->method('getName')->willReturn('Product Name');
+        $product->method('getImage')->willReturn(null);
+        $product->method('getFinalPrice')->willReturn($finalPrice);
+        $product->method('getCustomAttribute')->willReturn(null);
+        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+        $product->method('getTypeId')->willReturn('simple');
+        $product->method('getData')->willReturnCallback(function ($value) {
+            if ($value === 'is_in_stock') {
+                return 1;
+            }
+            if ($value === 'qty') {
+                return 2;
+            }
+            return null;
+        });
+
+        $line = $generator->callGenerateProductLine($product, $storeId, $parent);
+
+        $expectedCategoryJson = json_encode([
+            ['id' => '10', 'name' => 'Category 1'],
+            ['id' => '20', 'name' => 'Category 2']
+        ]);
+
+        $expectedLine = implode("\t", [
+            'CHILDPLUS1',
+            'Product Name',
+            'https://example.com/p',
+            '', // image_url
+            '2', // stock (in stock)
+            '1', // active
+            $expectedCategoryJson,
+            'PARENTFORWARDSLASH1', // virtual_parent_code
             '', // members
             '', // brand
             'USD',

--- a/Test/Unit/Service/Feed/CommerceFeedGeneratorTest.php
+++ b/Test/Unit/Service/Feed/CommerceFeedGeneratorTest.php
@@ -181,6 +181,35 @@ class CommerceFeedGeneratorTest extends TestCase
         );
     }
 
+    /**
+     * Mutates the feed stream property on the generator using native property scope binding.
+     *
+     * @param mixed $value
+     * @return void
+     */
+    private function setGeneratorStream($value): void
+    {
+        $setter = function ($value): void {
+            $this->stream = $value;
+        };
+        $setter = $setter->bindTo($this->generator, $this->generator::class);
+        $setter($value);
+    }
+
+    /**
+     * Reads the feed stream property on the generator using native property scope binding.
+     *
+     * @return mixed
+     */
+    private function getGeneratorStream()
+    {
+        $getter = function () {
+            return $this->stream;
+        };
+        $getter = $getter->bindTo($this->generator, $this->generator::class);
+        return $getter();
+    }
+
     public function testGetMembersForBundleProduct()
     {
         $product = $this->createMock(CatalogProduct::class);
@@ -691,28 +720,17 @@ class CommerceFeedGeneratorTest extends TestCase
         $this->generator->beginFeed($store);
         $this->assertTrue($this->generator->isFeedOpen());
 
-        $streamProperty = new \ReflectionProperty($this->generator, 'stream');
-        $streamProperty->setAccessible(true);
-        $streamProperty->setValue($this->generator, null);
-
-        $previousErrorHandler = set_error_handler(function ($severity, $message, $file, $line) {
-            throw new \ErrorException($message, 0, $severity, $file, $line);
-        });
+        $this->setGeneratorStream(null);
 
         try {
             $this->generator->finishFeed();
             $this->fail('Expected finishFeed to throw an exception when stream resource is invalid');
-        } catch (\ErrorException $e) {
-            $this->assertStringContainsString('rewind', $e->getMessage());
+        } catch (\LogicException $e) {
+            $this->assertStringContainsString('Feed stream is invalid', $e->getMessage());
         } finally {
-            if ($previousErrorHandler === null) {
-                restore_error_handler();
-            } else {
-                set_error_handler($previousErrorHandler);
-            }
+            $this->setGeneratorStream(null);
+            $this->assertFalse($this->generator->isFeedOpen());
+            $this->assertNull($this->getGeneratorStream());
         }
-
-        $this->assertFalse($this->generator->isFeedOpen());
-        $this->assertNull($streamProperty->getValue($this->generator));
     }
 }

--- a/Test/Unit/Service/Feed/CommerceFeedGeneratorTest.php
+++ b/Test/Unit/Service/Feed/CommerceFeedGeneratorTest.php
@@ -673,4 +673,46 @@ class CommerceFeedGeneratorTest extends TestCase
 
         $this->assertTrue($result);
     }
+
+    public function testFinishFeedThrowsWhenCalledWithoutBeginFeed()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Feed stream is not initialized. Call beginFeed() before finishFeed().');
+
+        $this->generator->finishFeed();
+    }
+
+    public function testFinishFeedCleansUpStateOnStreamError()
+    {
+        $store = $this->createMock(Store::class);
+        $store->method('getName')->willReturn('Test Store');
+        $store->method('getBaseUrl')->willReturn('https://example.test/');
+
+        $this->generator->beginFeed($store);
+        $this->assertTrue($this->generator->isFeedOpen());
+
+        $streamProperty = new \ReflectionProperty($this->generator, 'stream');
+        $streamProperty->setAccessible(true);
+        $streamProperty->setValue($this->generator, null);
+
+        $previousErrorHandler = set_error_handler(function ($severity, $message, $file, $line) {
+            throw new \ErrorException($message, 0, $severity, $file, $line);
+        });
+
+        try {
+            $this->generator->finishFeed();
+            $this->fail('Expected finishFeed to throw an exception when stream resource is invalid');
+        } catch (\ErrorException $e) {
+            $this->assertStringContainsString('rewind', $e->getMessage());
+        } finally {
+            if ($previousErrorHandler === null) {
+                restore_error_handler();
+            } else {
+                set_error_handler($previousErrorHandler);
+            }
+        }
+
+        $this->assertFalse($this->generator->isFeedOpen());
+        $this->assertNull($streamProperty->getValue($this->generator));
+    }
 }

--- a/Test/Unit/Service/Feed/CommerceFeedGeneratorTest.php
+++ b/Test/Unit/Service/Feed/CommerceFeedGeneratorTest.php
@@ -16,6 +16,7 @@ use Magento\GroupedProduct\Model\Product\Type\Grouped as GroupedType;
 use Magento\Directory\Model\Currency;
 use Magento\Eav\Model\Config as EavConfig;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Store\Model\Store;
 use PHPUnit\Framework\TestCase;
 use TurnTo\SocialCommerce\Model\Config as ConfigModel;
 use TurnTo\SocialCommerce\Model\Config\Gtin;
@@ -248,5 +249,84 @@ class CommerceFeedGeneratorTest extends TestCase
         ]);
 
         $this->assertEquals($expectedLine, $line);
+    }
+
+    public function testAddProductReturnsFalseIfProductCanNotBeAddedToFeed()
+    {
+        $storeId = 1;
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('');
+
+        $this->assertFalse($this->generator->addProduct($product, false, $storeId));
+    }
+
+    public function testAddProductReturnsTrueForValidProduct()
+    {
+        $storeId = 1;
+        $finalPrice = 12.34;
+
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $priceCurrency
+            ->method('convertAndRound')
+            ->with($finalPrice, $storeId)
+            ->willReturn($finalPrice);
+
+        $currencyMock = $this->createPartialMock(
+            Currency::class,
+            ['getCurrencyCode']
+        );
+        $currencyMock->method('getCurrencyCode')->willReturn('USD');
+        $priceCurrency->method('getCurrency')->with($storeId)->willReturn($currencyMock);
+
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return (string) $value;
+        });
+        $eavConfig = $this->createMock(EavConfig::class);
+        $logger = $this->createMock(Monolog::class);
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.com/p');
+
+        $generator = new TestableCommerceFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $exportProduct
+        );
+
+        $store = $this->createMock(Store::class);
+        $store->method('getName')->willReturn('Test Store');
+        $store->method('getBaseUrl')->willReturn('https://example.test/');
+
+        $generator->beginFeed($store);
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('SKU-1');
+        $product->method('getName')->willReturn('Product Name');
+        $product->method('getImage')->willReturn(null);
+        $product->method('getFinalPrice')->willReturn($finalPrice);
+        $product->method('getCustomAttribute')->willReturn(null);
+        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+        $product->method('getTypeId')->willReturn('simple');
+        $product->method('getData')->willReturnCallback(function ($value) {
+            if ($value === 'is_in_stock') {
+                return 1;
+            }
+            if ($value === 'qty') {
+                return 2;
+            }
+            return null;
+        });
+
+        $result = $generator->addProduct($product, false, $storeId);
+
+        $this->assertTrue($result);
     }
 }

--- a/Test/Unit/Service/Feed/CommerceFeedGeneratorTest.php
+++ b/Test/Unit/Service/Feed/CommerceFeedGeneratorTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace TurnTo\SocialCommerce\Test\Unit\Service\Feed;
 
 use Magento\Catalog\Helper\Image;
+use Magento\Catalog\Model\Category;
 use Magento\Catalog\Model\Product as CatalogProduct;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Bundle\Model\Product\Type as BundleType;
@@ -20,6 +21,7 @@ use Magento\Store\Model\Store;
 use PHPUnit\Framework\TestCase;
 use TurnTo\SocialCommerce\Model\Config as ConfigModel;
 use TurnTo\SocialCommerce\Model\Config\Gtin;
+use TurnTo\SocialCommerce\Model\Export\CategoryPathResolver;
 use TurnTo\SocialCommerce\Model\Export\Product as ExportProduct;
 use TurnTo\SocialCommerce\Model\Product;
 use TurnTo\SocialCommerce\Logger\Monolog;
@@ -38,6 +40,7 @@ class TestableCommerceFeedGenerator extends CommerceFeedGenerator
      * @param EavConfig $eavConfig
      * @param PriceCurrencyInterface $priceCurrency
      * @param Monolog $logger
+     * @param CategoryPathResolver $categoryPathResolver
      * @param ExportProduct $exportProduct
      */
     public function __construct(
@@ -48,6 +51,7 @@ class TestableCommerceFeedGenerator extends CommerceFeedGenerator
         EavConfig $eavConfig,
         PriceCurrencyInterface $priceCurrency,
         Monolog $logger,
+        CategoryPathResolver $categoryPathResolver,
         ExportProduct $exportProduct
     ) {
         parent::__construct(
@@ -58,6 +62,7 @@ class TestableCommerceFeedGenerator extends CommerceFeedGenerator
             $eavConfig,
             $priceCurrency,
             $logger,
+            $categoryPathResolver,
             $exportProduct
         );
     }
@@ -89,6 +94,49 @@ class TestableCommerceFeedGenerator extends CommerceFeedGenerator
     {
         return 'Category 1 > Category 2';
     }
+
+    /**
+     * @param CatalogProduct $product
+     * @param int|string|null $storeId
+     * @return array
+     */
+    protected function getDeepestCategoryTree(CatalogProduct $product, $storeId)
+    {
+        return [
+            $this->getCategoryFixture('Category 1', 100),
+            $this->getCategoryFixture('Category 2', 200)
+        ];
+    }
+
+    /**
+     * @param string $name
+     * @param int $id
+     * @return Category
+     */
+    protected function getCategoryFixture(string $name, int $id)
+    {
+        $category = new class($name, $id) {
+            private string $name;
+            private int $id;
+
+            public function __construct(string $name, int $id)
+            {
+                $this->name = $name;
+                $this->id = $id;
+            }
+
+            public function getName(): string
+            {
+                return $this->name;
+            }
+
+            public function getId(): int
+            {
+                return $this->id;
+            }
+        };
+        return $category;
+    }
 }
 
 class CommerceFeedGeneratorTest extends TestCase
@@ -97,6 +145,10 @@ class CommerceFeedGeneratorTest extends TestCase
      * @var TestableCommerceFeedGenerator
      */
     protected $generator;
+    /**
+     * @var CategoryPathResolver
+     */
+    protected $categoryPathResolver;
 
     protected function setUp(): void
     {
@@ -114,6 +166,7 @@ class CommerceFeedGeneratorTest extends TestCase
 
         $exportProduct = $this->createMock(ExportProduct::class);
         $exportProduct->method('getProductUrl')->willReturn('https://example.test/p');
+        $this->categoryPathResolver = $this->createMock(CategoryPathResolver::class);
 
         $this->generator = new TestableCommerceFeedGenerator(
             $config,
@@ -123,6 +176,7 @@ class CommerceFeedGeneratorTest extends TestCase
             $eavConfig,
             $priceCurrency,
             $logger,
+            $this->categoryPathResolver,
             $exportProduct
         );
     }
@@ -212,6 +266,7 @@ class CommerceFeedGeneratorTest extends TestCase
             $eavConfig,
             $priceCurrency,
             $logger,
+            $this->categoryPathResolver,
             $exportProduct
         );
 
@@ -260,6 +315,7 @@ class CommerceFeedGeneratorTest extends TestCase
             $eavConfig,
             $priceCurrency,
             $logger,
+            $this->categoryPathResolver,
             $exportProduct
         );
 
@@ -308,6 +364,7 @@ class CommerceFeedGeneratorTest extends TestCase
             $eavConfig,
             $priceCurrency,
             $logger,
+            $this->categoryPathResolver,
             $exportProduct
         );
 
@@ -323,8 +380,8 @@ class CommerceFeedGeneratorTest extends TestCase
         $line = $generator->callGenerateProductLine($product, $storeId, false);
 
         $expectedCategoryJson = json_encode([
-            ['id' => '10', 'name' => 'Category 1'],
-            ['id' => '20', 'name' => 'Category 2']
+            ['id' => '100', 'name' => 'Category 1'],
+            ['id' => '200', 'name' => 'Category 2']
         ]);
 
         $expectedLine = implode("\t", [
@@ -391,6 +448,7 @@ class CommerceFeedGeneratorTest extends TestCase
             $eavConfig,
             $priceCurrency,
             $logger,
+            $this->categoryPathResolver,
             $exportProduct
         );
 
@@ -415,8 +473,8 @@ class CommerceFeedGeneratorTest extends TestCase
         $line = $generator->callGenerateProductLine($product, $storeId, false);
 
         $expectedCategoryJson = json_encode([
-            ['id' => '10', 'name' => 'Category 1'],
-            ['id' => '20', 'name' => 'Category 2']
+            ['id' => '100', 'name' => 'Category 1'],
+            ['id' => '200', 'name' => 'Category 2']
         ]);
 
         $expectedLine = implode("\t", [
@@ -483,6 +541,7 @@ class CommerceFeedGeneratorTest extends TestCase
             $eavConfig,
             $priceCurrency,
             $logger,
+            $this->categoryPathResolver,
             $exportProduct
         );
 
@@ -510,8 +569,8 @@ class CommerceFeedGeneratorTest extends TestCase
         $line = $generator->callGenerateProductLine($product, $storeId, $parent);
 
         $expectedCategoryJson = json_encode([
-            ['id' => '10', 'name' => 'Category 1'],
-            ['id' => '20', 'name' => 'Category 2']
+            ['id' => '100', 'name' => 'Category 1'],
+            ['id' => '200', 'name' => 'Category 2']
         ]);
 
         $expectedLine = implode("\t", [
@@ -582,6 +641,7 @@ class CommerceFeedGeneratorTest extends TestCase
             $eavConfig,
             $priceCurrency,
             $logger,
+            $this->categoryPathResolver,
             $exportProduct
         );
 

--- a/Test/Unit/Service/Feed/FeedGeneratorFactoryTest.php
+++ b/Test/Unit/Service/Feed/FeedGeneratorFactoryTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Test\Unit\Service\Feed;
+
+use PHPUnit\Framework\TestCase;
+use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
+use TurnTo\SocialCommerce\Service\Feed\CommerceFeedGenerator;
+use TurnTo\SocialCommerce\Service\Feed\FeedGeneratorFactory;
+use TurnTo\SocialCommerce\Service\Feed\GoogleFeedGenerator;
+
+class FeedGeneratorFactoryTest extends TestCase
+{
+    /**
+     * @var FeedGeneratorFactory
+     */
+    protected $factory;
+
+    /**
+     * @var GoogleFeedGenerator
+     */
+    protected $googleGenerator;
+
+    /**
+     * @var CommerceFeedGenerator
+     */
+    protected $commerceGenerator;
+
+    protected function setUp(): void
+    {
+        $this->googleGenerator = $this->createMock(GoogleFeedGenerator::class);
+        $this->commerceGenerator = $this->createMock(CommerceFeedGenerator::class);
+
+        $generators = [
+            FeedFormat::GOOGLE_PRODUCT => $this->googleGenerator,
+            FeedFormat::COMMERCE => $this->commerceGenerator
+        ];
+
+        $this->factory = new FeedGeneratorFactory($generators);
+    }
+
+    public function testCreateGoogleFeedGenerator()
+    {
+        $result = $this->factory->create(FeedFormat::GOOGLE_PRODUCT);
+        $this->assertSame($this->googleGenerator, $result);
+    }
+
+    public function testCreateCommerceFeedGenerator()
+    {
+        $result = $this->factory->create(FeedFormat::COMMERCE);
+        $this->assertSame($this->commerceGenerator, $result);
+    }
+
+    public function testCreateThrowsExceptionForInvalidFormat()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid feed format: invalid_format');
+
+        $this->factory->create('invalid_format');
+    }
+}

--- a/Test/Unit/Service/Feed/FeedGeneratorFactoryTest.php
+++ b/Test/Unit/Service/Feed/FeedGeneratorFactoryTest.php
@@ -35,9 +35,15 @@ class FeedGeneratorFactoryTest extends TestCase
         $this->googleGenerator = $this->createMock(GoogleFeedGenerator::class);
         $this->commerceGenerator = $this->createMock(CommerceFeedGenerator::class);
 
+        $googleFactory = $this->createMock(\TurnTo\SocialCommerce\Service\Feed\GoogleFeedGeneratorFactory::class);
+        $googleFactory->method('create')->willReturn($this->googleGenerator);
+
+        $commerceFactory = $this->createMock(\TurnTo\SocialCommerce\Service\Feed\CommerceFeedGeneratorFactory::class);
+        $commerceFactory->method('create')->willReturn($this->commerceGenerator);
+
         $generators = [
-            FeedFormat::GOOGLE_PRODUCT => $this->googleGenerator,
-            FeedFormat::COMMERCE => $this->commerceGenerator
+            FeedFormat::GOOGLE_PRODUCT => $googleFactory,
+            FeedFormat::COMMERCE => $commerceFactory
         ];
 
         $this->factory = new FeedGeneratorFactory($generators);

--- a/Test/Unit/Service/Feed/GoogleFeedGeneratorTest.php
+++ b/Test/Unit/Service/Feed/GoogleFeedGeneratorTest.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Test\Unit\Service\Feed;
+
+use Magento\Catalog\Helper\Image;
+use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Directory\Model\Currency;
+use Magento\Framework\Intl\DateTimeFactory;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Eav\Model\Config as EavConfig;
+use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
+use PHPUnit\Framework\TestCase;
+use SimpleXMLElement;
+use TurnTo\SocialCommerce\Model\Config as ConfigModel;
+use TurnTo\SocialCommerce\Model\Config\Gtin;
+use TurnTo\SocialCommerce\Model\Export\Product as ExportProduct;
+use TurnTo\SocialCommerce\Model\Product;
+use TurnTo\SocialCommerce\Logger\Monolog;
+use TurnTo\SocialCommerce\Service\Feed\GoogleFeedGenerator;
+
+/**
+ * Exposes protected feed helpers for unit testing.
+ */
+class TestableGoogleFeedGenerator extends GoogleFeedGenerator
+{
+    /**
+     * @param SimpleXMLElement $entry
+     * @param CatalogProduct $product
+     * @param int|string $storeId
+     * @param bool|CatalogProduct $parent
+     * @return void
+     */
+    public function callAddProductToAtomFeed($entry, $product, $storeId, $parent)
+    {
+        $this->addProductToAtomFeed($entry, $product, $storeId, $parent);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getCategoryTreeString(CatalogProduct $product, $storeId)
+    {
+        return '';
+    }
+}
+
+class GoogleFeedGeneratorTest extends TestCase
+{
+    /**
+     * @var TestableGoogleFeedGenerator
+     */
+    protected $generator;
+
+    /**
+     * @var EavConfig
+     */
+    protected $eavConfig;
+
+    protected function setUp(): void
+    {
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $this->eavConfig = $this->createMock(EavConfig::class);
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $logger = $this->createMock(Monolog::class);
+        $dateTimeFactory = $this->createMock(DateTimeFactory::class);
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.test/p');
+
+        $this->generator = new TestableGoogleFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $this->eavConfig,
+            $priceCurrency,
+            $logger,
+            $dateTimeFactory,
+            $exportProduct
+        );
+    }
+
+    public function testGetGtinValueReturnsLabelForSelectAttribute()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $attribute = $this->getMockBuilder(AbstractAttribute::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['usesSource'])
+            ->getMock();
+        $attribute->method('usesSource')->willReturn(true);
+        $this->eavConfig->method('getAttribute')->willReturn($attribute);
+
+        $product->method('getAttributeText')
+            ->with('upc')
+            ->willReturn('UPC Label');
+
+        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
+        $this->assertSame('UPC Label', $this->generator->getGtinValue($product, $gtinMap));
+    }
+
+    public function testGetGtinValueReturnsCommaSeparatedForMultiselect()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $attribute = $this->getMockBuilder(AbstractAttribute::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['usesSource'])
+            ->getMock();
+        $attribute->method('usesSource')->willReturn(true);
+        $this->eavConfig->method('getAttribute')->willReturn($attribute);
+
+        $product->method('getAttributeText')
+            ->with('upc')
+            ->willReturn(['Red', 'Blue']);
+
+        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
+        $this->assertSame('Red, Blue', $this->generator->getGtinValue($product, $gtinMap));
+    }
+
+    public function testGetGtinValueReturnsRawForNonSourceAttribute()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $attribute = $this->getMockBuilder(AbstractAttribute::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['usesSource'])
+            ->getMock();
+        $attribute->method('usesSource')->willReturn(false);
+        $this->eavConfig->method('getAttribute')->willReturn($attribute);
+
+        $product->method('getData')
+            ->with('upc')
+            ->willReturn('12345');
+
+        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
+        $this->assertSame('12345', $this->generator->getGtinValue($product, $gtinMap));
+    }
+
+    public function testGetGtinValueReturnsImplodedForArrayData()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $attribute = $this->getMockBuilder(AbstractAttribute::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['usesSource'])
+            ->getMock();
+        $attribute->method('usesSource')->willReturn(false);
+        $this->eavConfig->method('getAttribute')->willReturn($attribute);
+
+        $product->method('getData')
+            ->with('upc')
+            ->willReturn([1, 2]);
+
+        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
+        $this->assertSame('1, 2', $this->generator->getGtinValue($product, $gtinMap));
+    }
+
+    public function testAddProductToAtomFeedWritesConvertedFinalPriceWithCurrency()
+    {
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $logger = $this->createMock(Monolog::class);
+        $dateTimeFactory = $this->createMock(DateTimeFactory::class);
+
+        // Ensure safe SKU encoding passthrough
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return (string) $value;
+        });
+
+        // Set expectations for currency conversion and currency code retrieval
+        $storeId = 1;
+        $finalPrice = 12.34;
+
+        $priceCurrency
+            ->expects($this->once())
+            ->method('convertAndRound')
+            ->with($finalPrice, $storeId)
+            ->willReturn($finalPrice);
+
+        $currencyMock = $this->createPartialMock(
+            Currency::class,
+            ['getCurrencyCode']
+        );
+        $currencyMock->method('getCurrencyCode')->willReturn('USD');
+        $priceCurrency->method('getCurrency')->with($storeId)->willReturn($currencyMock);
+
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.com/p');
+
+        $generator = new TestableGoogleFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $this->eavConfig,
+            $priceCurrency,
+            $logger,
+            $dateTimeFactory,
+            $exportProduct
+        );
+
+        // Minimal product stub to satisfy feed requirements
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('SKU-1');
+        $product->method('getName')->willReturn('Product Name');
+        $product->method('getImage')->willReturn(null); // avoid image helper chain
+        $product->method('getFinalPrice')->willReturn($finalPrice);
+        $product->method('getCustomAttribute')->willReturn(null);
+        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+
+        $entry = new SimpleXMLElement('<entry />');
+
+        // Execute
+        $generator->callAddProductToAtomFeed($entry, $product, $storeId, false);
+
+        // Assert price element is present and formatted with currency code
+        $xmlString = $entry->asXML();
+        $this->assertIsString($xmlString);
+        $this->assertStringContainsString('<price>12.34 USD</price>', $xmlString);
+    }
+}

--- a/Test/Unit/Service/Feed/GoogleFeedGeneratorTest.php
+++ b/Test/Unit/Service/Feed/GoogleFeedGeneratorTest.php
@@ -380,4 +380,46 @@ class GoogleFeedGeneratorTest extends TestCase
 
         $this->assertTrue($result);
     }
+
+    public function testFinishFeedThrowsWhenCalledWithoutBeginFeed()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Feed stream is not initialized. Call beginFeed() before finishFeed().');
+
+        $this->generator->finishFeed();
+    }
+
+    public function testFinishFeedCleansUpStateOnStreamError()
+    {
+        $store = $this->createMock(Store::class);
+        $store->method('getName')->willReturn('Test Store');
+        $store->method('getBaseUrl')->willReturn('https://example.test/');
+
+        $this->generator->beginFeed($store);
+        $this->assertTrue($this->generator->isFeedOpen());
+
+        $streamProperty = new \ReflectionProperty($this->generator, 'stream');
+        $streamProperty->setAccessible(true);
+        $streamProperty->setValue($this->generator, null);
+
+        $previousErrorHandler = set_error_handler(function ($severity, $message, $file, $line) {
+            throw new \ErrorException($message, 0, $severity, $file, $line);
+        });
+
+        try {
+            $this->generator->finishFeed();
+            $this->fail('Expected finishFeed to throw an exception when stream resource is invalid');
+        } catch (\ErrorException $e) {
+            $this->assertStringContainsString('rewind', $e->getMessage());
+        } finally {
+            if ($previousErrorHandler === null) {
+                restore_error_handler();
+            } else {
+                set_error_handler($previousErrorHandler);
+            }
+        }
+
+        $this->assertFalse($this->generator->isFeedOpen());
+        $this->assertNull($streamProperty->getValue($this->generator));
+    }
 }

--- a/Test/Unit/Service/Feed/GoogleFeedGeneratorTest.php
+++ b/Test/Unit/Service/Feed/GoogleFeedGeneratorTest.php
@@ -15,6 +15,7 @@ use Magento\Framework\Intl\DateTimeFactory;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Eav\Model\Config as EavConfig;
 use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
+use Magento\Store\Model\Store;
 use PHPUnit\Framework\TestCase;
 use SimpleXMLElement;
 use TurnTo\SocialCommerce\Model\Config as ConfigModel;
@@ -224,6 +225,82 @@ class GoogleFeedGeneratorTest extends TestCase
         // Assert price element is present and formatted with currency code
         $xmlString = $entry->asXML();
         $this->assertIsString($xmlString);
-        $this->assertStringContainsString('<price>12.34 USD</price>', $xmlString);
+        $this->assertStringContainsString(
+            '<g:price xmlns:g="http://base.google.com/ns/1.0">12.34 USD</g:price>',
+            $xmlString
+        );
+    }
+
+    public function testAddProductReturnsFalseIfProductCanNotBeAdded()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('');
+
+        $this->assertFalse($this->generator->addProduct($product, false, 1));
+    }
+
+    public function testAddProductReturnsTrueForValidProduct()
+    {
+        $storeId = 1;
+        $finalPrice = 12.34;
+
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return (string) $value;
+        });
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $logger = $this->createMock(Monolog::class);
+        $dateTimeFactory = $this->createMock(DateTimeFactory::class);
+        $dateTime = $this->createMock(\DateTime::class);
+        $dateTime->method('format')->willReturn('2026-01-01T00:00:00+00:00');
+        $dateTimeFactory->method('create')->willReturn($dateTime);
+
+        $priceCurrency
+            ->method('convertAndRound')
+            ->with($finalPrice, $storeId)
+            ->willReturn($finalPrice);
+
+        $currencyMock = $this->createPartialMock(
+            Currency::class,
+            ['getCurrencyCode']
+        );
+        $currencyMock->method('getCurrencyCode')->willReturn('USD');
+        $priceCurrency->method('getCurrency')->with($storeId)->willReturn($currencyMock);
+
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.com/p');
+
+        $generator = new TestableGoogleFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $this->eavConfig,
+            $priceCurrency,
+            $logger,
+            $dateTimeFactory,
+            $exportProduct
+        );
+
+        $store = $this->createMock(Store::class);
+        $store->method('getName')->willReturn('Test Store');
+        $store->method('getBaseUrl')->willReturn('https://example.test/');
+
+        $generator->beginFeed($store);
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('SKU-1');
+        $product->method('getName')->willReturn('Product Name');
+        $product->method('getImage')->willReturn(null);
+        $product->method('getFinalPrice')->willReturn($finalPrice);
+        $product->method('getCustomAttribute')->willReturn(null);
+        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+
+        $result = $generator->addProduct($product, false, $storeId);
+
+        $this->assertTrue($result);
     }
 }

--- a/Test/Unit/Service/Feed/GoogleFeedGeneratorTest.php
+++ b/Test/Unit/Service/Feed/GoogleFeedGeneratorTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\TestCase;
 use SimpleXMLElement;
 use TurnTo\SocialCommerce\Model\Config as ConfigModel;
 use TurnTo\SocialCommerce\Model\Config\Gtin;
+use TurnTo\SocialCommerce\Model\Export\CategoryPathResolver;
 use TurnTo\SocialCommerce\Model\Export\Product as ExportProduct;
 use TurnTo\SocialCommerce\Model\Product;
 use TurnTo\SocialCommerce\Logger\Monolog;
@@ -62,6 +63,10 @@ class GoogleFeedGeneratorTest extends TestCase
      * @var EavConfig
      */
     protected $eavConfig;
+    /**
+     * @var CategoryPathResolver
+     */
+    protected $categoryPathResolver;
 
     protected function setUp(): void
     {
@@ -74,6 +79,7 @@ class GoogleFeedGeneratorTest extends TestCase
         $logger = $this->createMock(Monolog::class);
         $dateTimeFactory = $this->createMock(DateTimeFactory::class);
         $exportProduct = $this->createMock(ExportProduct::class);
+        $this->categoryPathResolver = $this->createMock(CategoryPathResolver::class);
         $exportProduct->method('getProductUrl')->willReturn('https://example.test/p');
 
         $this->generator = new TestableGoogleFeedGenerator(
@@ -85,6 +91,7 @@ class GoogleFeedGeneratorTest extends TestCase
             $priceCurrency,
             $logger,
             $dateTimeFactory,
+            $this->categoryPathResolver,
             $exportProduct
         );
     }
@@ -205,6 +212,7 @@ class GoogleFeedGeneratorTest extends TestCase
             $priceCurrency,
             $logger,
             $dateTimeFactory,
+            $this->categoryPathResolver,
             $exportProduct
         );
 
@@ -274,6 +282,7 @@ class GoogleFeedGeneratorTest extends TestCase
             $priceCurrency,
             $logger,
             $dateTimeFactory,
+            $this->categoryPathResolver,
             $exportProduct
         );
 
@@ -349,6 +358,7 @@ class GoogleFeedGeneratorTest extends TestCase
             $priceCurrency,
             $logger,
             $dateTimeFactory,
+            $this->categoryPathResolver,
             $exportProduct
         );
 

--- a/Test/Unit/Service/Feed/GoogleFeedGeneratorTest.php
+++ b/Test/Unit/Service/Feed/GoogleFeedGeneratorTest.php
@@ -78,6 +78,9 @@ class GoogleFeedGeneratorTest extends TestCase
         $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
         $logger = $this->createMock(Monolog::class);
         $dateTimeFactory = $this->createMock(DateTimeFactory::class);
+        $dateTime = $this->createMock(\DateTime::class);
+        $dateTime->method('format')->willReturn('2026-01-01T00:00:00+00:00');
+        $dateTimeFactory->method('create')->willReturn($dateTime);
         $exportProduct = $this->createMock(ExportProduct::class);
         $this->categoryPathResolver = $this->createMock(CategoryPathResolver::class);
         $exportProduct->method('getProductUrl')->willReturn('https://example.test/p');
@@ -94,6 +97,35 @@ class GoogleFeedGeneratorTest extends TestCase
             $this->categoryPathResolver,
             $exportProduct
         );
+    }
+
+    /**
+     * Mutates the feed stream property on the generator using native property scope binding.
+     *
+     * @param mixed $value
+     * @return void
+     */
+    private function setGeneratorStream($value): void
+    {
+        $setter = function ($value): void {
+            $this->stream = $value;
+        };
+        $setter = $setter->bindTo($this->generator, $this->generator::class);
+        $setter($value);
+    }
+
+    /**
+     * Reads the feed stream property on the generator using native property scope binding.
+     *
+     * @return mixed
+     */
+    private function getGeneratorStream()
+    {
+        $getter = function () {
+            return $this->stream;
+        };
+        $getter = $getter->bindTo($this->generator, $this->generator::class);
+        return $getter();
     }
 
     public function testGetGtinValueReturnsLabelForSelectAttribute()
@@ -398,28 +430,17 @@ class GoogleFeedGeneratorTest extends TestCase
         $this->generator->beginFeed($store);
         $this->assertTrue($this->generator->isFeedOpen());
 
-        $streamProperty = new \ReflectionProperty($this->generator, 'stream');
-        $streamProperty->setAccessible(true);
-        $streamProperty->setValue($this->generator, null);
-
-        $previousErrorHandler = set_error_handler(function ($severity, $message, $file, $line) {
-            throw new \ErrorException($message, 0, $severity, $file, $line);
-        });
+        $this->setGeneratorStream(null);
 
         try {
             $this->generator->finishFeed();
             $this->fail('Expected finishFeed to throw an exception when stream resource is invalid');
-        } catch (\ErrorException $e) {
-            $this->assertStringContainsString('rewind', $e->getMessage());
+        } catch (\LogicException $e) {
+            $this->assertStringContainsString('Feed stream is invalid', $e->getMessage());
         } finally {
-            if ($previousErrorHandler === null) {
-                restore_error_handler();
-            } else {
-                set_error_handler($previousErrorHandler);
-            }
+            $this->setGeneratorStream(null);
+            $this->assertFalse($this->generator->isFeedOpen());
+            $this->assertNull($this->getGeneratorStream());
         }
-
-        $this->assertFalse($this->generator->isFeedOpen());
-        $this->assertNull($streamProperty->getValue($this->generator));
     }
 }

--- a/Test/Unit/Service/Feed/GoogleFeedGeneratorTest.php
+++ b/Test/Unit/Service/Feed/GoogleFeedGeneratorTest.php
@@ -231,6 +231,73 @@ class GoogleFeedGeneratorTest extends TestCase
         );
     }
 
+    public function testAddProductToAtomFeedWritesEncodedItemGroupIdFromParent()
+    {
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $logger = $this->createMock(Monolog::class);
+        $dateTimeFactory = $this->createMock(DateTimeFactory::class);
+
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return str_replace(
+                array_keys(Product::TURNTO_CHARACTER_MAPPING),
+                array_values(Product::TURNTO_CHARACTER_MAPPING),
+                (string) $value
+            );
+        });
+
+        $priceCurrency
+            ->expects($this->once())
+            ->method('convertAndRound')
+            ->with(12.34, 1)
+            ->willReturn(12.34);
+
+        $currencyMock = $this->createPartialMock(
+            Currency::class,
+            ['getCurrencyCode']
+        );
+        $currencyMock->method('getCurrencyCode')->willReturn('USD');
+        $priceCurrency->method('getCurrency')->with(1)->willReturn($currencyMock);
+
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.com/p');
+
+        $generator = new TestableGoogleFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $this->eavConfig,
+            $priceCurrency,
+            $logger,
+            $dateTimeFactory,
+            $exportProduct
+        );
+
+        $parent = $this->createMock(CatalogProduct::class);
+        $parent->method('getSku')->willReturn('PARENT/1');
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('CHILD+1');
+        $product->method('getName')->willReturn('Product Name');
+        $product->method('getImage')->willReturn(null);
+        $product->method('getFinalPrice')->willReturn(12.34);
+        $product->method('getCustomAttribute')->willReturn(null);
+        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+
+        $entry = new SimpleXMLElement('<entry />');
+        $generator->callAddProductToAtomFeed($entry, $product, 1, $parent);
+
+        $xmlString = $entry->asXML();
+        $this->assertStringContainsString(
+            '<g:item_group_id xmlns:g="http://base.google.com/ns/1.0">PARENTFORWARDSLASH1</g:item_group_id>',
+            $xmlString
+        );
+    }
+
     public function testAddProductReturnsFalseIfProductCanNotBeAdded()
     {
         $product = $this->createMock(CatalogProduct::class);

--- a/Test/Unit/Service/GoogleFeed/ClientTest.php
+++ b/Test/Unit/Service/GoogleFeed/ClientTest.php
@@ -61,16 +61,16 @@ class ClientTest extends TestCase
     public function testTransmitFeedFileSuccessWritesRequestAndReturns()
     {
         $response = $this->createResponse(200, 'SUCCESS');
+        $writeCalls = [];
         $this->client->expects($this->once())
             ->method('request')
             ->willReturn($response);
 
         $this->file->expects($this->exactly(2))
             ->method('writeFile')
-            ->withConsecutive(
-                ['turnto/commerce-product_storecode_default.tsv', 'feed-content'],
-                ['turnto/commerce-product_storecode_default_request.txt', 'SUCCESS']
-            );
+            ->willReturnCallback(function ($fileName, $contents) use (&$writeCalls) {
+                $writeCalls[] = [$fileName, $contents];
+            });
         $this->logger->expects($this->never())->method('warning');
         $this->logger->expects($this->never())->method('error');
 
@@ -85,6 +85,14 @@ class ClientTest extends TestCase
             'catalog.tsv',
             FeedFormat::COMMERCE,
             'default'
+        );
+
+        $this->assertSame(
+            [
+                ['turnto/commerce-product_storecode_default.tsv', 'feed-content'],
+                ['turnto/commerce-product_storecode_default_request.txt', 'SUCCESS']
+            ],
+            $writeCalls
         );
     }
 

--- a/Test/Unit/Service/GoogleFeed/ClientTest.php
+++ b/Test/Unit/Service/GoogleFeed/ClientTest.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Test\Unit\Service\GoogleFeed;
+
+use Exception;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\TransferException;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use TurnTo\SocialCommerce\Logger\Monolog;
+use TurnTo\SocialCommerce\Model\Config;
+use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
+use TurnTo\SocialCommerce\Model\File;
+use TurnTo\SocialCommerce\Service\GoogleFeed\Client;
+
+class TestableClient extends Client
+{
+    protected function getRetryDelayMicroseconds(int $attempt): int
+    {
+        return 0;
+    }
+}
+
+class ClientTest extends TestCase
+{
+    /**
+     * @var Config
+     */
+    protected $config;
+    /**
+     * @var GuzzleClient
+     */
+    protected $client;
+    /**
+     * @var File
+     */
+    protected $file;
+    /**
+     * @var Monolog
+     */
+    protected $logger;
+
+    protected function setUp(): void
+    {
+        $this->config = $this->createMock(Config::class);
+        $this->client = $this->createMock(GuzzleClient::class);
+        $this->file = $this->createMock(File::class);
+        $this->logger = $this->createMock(Monolog::class);
+
+        $this->config->method('getConfigValue')->willReturn('https://feed.test/upload');
+        $this->config->method('getSiteKey')->willReturn('site-key');
+        $this->config->method('getAuthorizationKey')->willReturn('auth-key');
+    }
+
+    public function testTransmitFeedFileSuccessWritesRequestAndReturns()
+    {
+        $response = $this->createResponse(200, 'SUCCESS');
+        $this->client->expects($this->once())
+            ->method('request')
+            ->willReturn($response);
+
+        $this->file->expects($this->exactly(2))
+            ->method('writeFile')
+            ->withConsecutive(
+                ['turnto/commerce-product_storecode_default.tsv', 'feed-content'],
+                ['turnto/commerce-product_storecode_default_request.txt', 'SUCCESS']
+            );
+        $this->logger->expects($this->never())->method('warning');
+        $this->logger->expects($this->never())->method('error');
+
+        $client = new TestableClient(
+            $this->config,
+            $this->logger,
+            $this->client,
+            $this->file
+        );
+        $client->transmitFeedFile(
+            'feed-content',
+            'catalog.tsv',
+            FeedFormat::COMMERCE,
+            'default'
+        );
+    }
+
+    public function testTransmitFeedFileRetriesOnServerErrorBeforeSuccess()
+    {
+        $serverError = $this->createResponse(500, 'Server unavailable');
+        $success = $this->createResponse(200, 'SUCCESS');
+        $this->client->expects($this->exactly(2))
+            ->method('request')
+            ->willReturnOnConsecutiveCalls($serverError, $success);
+
+        $this->logger->expects($this->once())->method('warning');
+        $this->logger->expects($this->never())->method('error');
+
+        $this->file->expects($this->any())->method('writeFile');
+
+        $client = new TestableClient(
+            $this->config,
+            $this->logger,
+            $this->client,
+            $this->file
+        );
+        $client->transmitFeedFile(
+            'feed-content',
+            'catalog.tsv',
+            FeedFormat::COMMERCE,
+            'default'
+        );
+    }
+
+    public function testTransmitFeedFileRetriesOnTooManyRequestsBeforeSuccess()
+    {
+        $rateLimitResponse = $this->createResponse(429, 'Too Many Requests');
+        $success = $this->createResponse(200, 'SUCCESS');
+        $this->client->expects($this->exactly(2))
+            ->method('request')
+            ->willReturnOnConsecutiveCalls($rateLimitResponse, $success);
+
+        $this->logger->expects($this->once())->method('warning');
+        $this->logger->expects($this->never())->method('error');
+
+        $this->file->expects($this->any())->method('writeFile');
+
+        $client = new TestableClient(
+            $this->config,
+            $this->logger,
+            $this->client,
+            $this->file
+        );
+        $client->transmitFeedFile(
+            'feed-content',
+            'catalog.tsv',
+            FeedFormat::COMMERCE,
+            'default'
+        );
+    }
+
+    public function testTransmitFeedFileDoesNotRetryForPermaErrorResponse()
+    {
+        $this->client->expects($this->once())
+            ->method('request')
+            ->willReturn($this->createResponse(400, 'Invalid request'));
+
+        $this->logger->expects($this->never())->method('warning');
+        $this->logger->expects($this->once())->method('error');
+
+        $this->expectException(Exception::class);
+
+        $client = new TestableClient(
+            $this->config,
+            $this->logger,
+            $this->client,
+            $this->file
+        );
+        $client->transmitFeedFile(
+            'feed-content',
+            'catalog.tsv',
+            FeedFormat::COMMERCE,
+            'default'
+        );
+    }
+
+    public function testTransmitFeedFileDoesNotRetryForErrorPayload()
+    {
+        $this->client->expects($this->once())
+            ->method('request')
+            ->willReturn($this->createResponse(200, 'Validation failed'));
+
+        $this->logger->expects($this->never())->method('warning');
+        $this->logger->expects($this->once())->method('error');
+
+        $this->expectException(Exception::class);
+
+        $client = new TestableClient(
+            $this->config,
+            $this->logger,
+            $this->client,
+            $this->file
+        );
+        $client->transmitFeedFile(
+            'feed-content',
+            'catalog.tsv',
+            FeedFormat::COMMERCE,
+            'default'
+        );
+    }
+
+    public function testTransmitFeedFileRetriesNetworkErrorUntilMaxAttempts()
+    {
+        $this->client->expects($this->exactly(3))
+            ->method('request')
+            ->willThrowException(new TransferException('network failure'));
+
+        $this->logger->expects($this->exactly(2))->method('warning');
+        $this->logger->expects($this->once())->method('error');
+
+        $this->expectException(TransferException::class);
+
+        $client = new TestableClient(
+            $this->config,
+            $this->logger,
+            $this->client,
+            $this->file
+        );
+        $client->transmitFeedFile(
+            'feed-content',
+            'catalog.tsv',
+            FeedFormat::COMMERCE,
+            'default'
+        );
+    }
+
+    protected function createResponse(int $statusCode, string $body): ResponseInterface
+    {
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('getContents')->willReturn($body);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn($statusCode);
+        $response->method('getBody')->willReturn($stream);
+
+        return $response;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         }
     ],
     "require": {
+        "ext-simplexml": "*",
         "magento/framework": "102.0.*||103.0.*",
         "magento/module-backend": "101.0.*||102.0.*",
         "magento/module-catalog": "103.0.*||104.0.*",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -210,6 +210,15 @@
                         <field id="turnto_socialcommerce_configuration/general/enabled">1</field>
                     </depends>
                 </field>
+                <field id="feed_format" translate="label comment" type="select" sortOrder="15" showInStore="1" showInWebsite="1" showInDefault="1">
+                    <label>Feed Format</label>
+                    <comment>Select the format for the product feed.</comment>
+                    <source_model>TurnTo\SocialCommerce\Model\Config\Source\FeedFormat</source_model>
+                    <depends>
+                        <field id="enable_automatic_submission">1</field>
+                        <field id="turnto_socialcommerce_configuration/general/enabled">1</field>
+                    </depends>
+                </field>
                 <field id="product_feed_url" translate="label comment" type="text" sortOrder="20" showInStore="1" showInWebsite="1" showInDefault="1">
                     <label>Product Ratings Feed URL</label>
                     <comment><![CDATA[The URL from which to retrieve the Emplifi SKU Average Rating Feed.<br>Default: <b>https://export.turnto.com/</b>]]></comment>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -212,7 +212,7 @@
                 </field>
                 <field id="feed_format" translate="label comment" type="select" sortOrder="15" showInStore="1" showInWebsite="1" showInDefault="1">
                     <label>Feed Format</label>
-                    <comment>Select the format for the product feed.</comment>
+                    <comment><![CDATA[Recommend commerce feed for new installs. Should not be changed, without contacting your Emplifi customer success team.]]></comment>
                     <source_model>TurnTo\SocialCommerce\Model\Config\Source\FeedFormat</source_model>
                     <depends>
                         <field id="enable_automatic_submission">1</field>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -46,6 +46,7 @@
             </gallery>
             <product_feed>
                 <enable_automatic_submission>1</enable_automatic_submission>
+                <feed_format>tab-style.commerce</feed_format>
                 <product_feed_url>https://export.turnto.com/</product_feed_url>
                 <feed_submission_url>https://www.turnto.com/feedUpload/postfile</feed_submission_url>
                 <review_api_url>https://cdn-ws.turnto.com/v5/sitedata/</review_api_url>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -46,7 +46,7 @@
             </gallery>
             <product_feed>
                 <enable_automatic_submission>1</enable_automatic_submission>
-                <feed_format>tab-style.commerce</feed_format>
+                <feed_format>google-product.xml</feed_format>
                 <product_feed_url>https://export.turnto.com/</product_feed_url>
                 <feed_submission_url>https://www.turnto.com/feedUpload/postfile</feed_submission_url>
                 <review_api_url>https://cdn-ws.turnto.com/v5/sitedata/</review_api_url>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -21,6 +21,14 @@
             </argument>
         </arguments>
     </type>
+    <type name="TurnTo\SocialCommerce\Service\Feed\FeedGeneratorFactory">
+        <arguments>
+            <argument name="generators" xsi:type="array">
+                <item name="google-product.xml" xsi:type="object">TurnTo\SocialCommerce\Service\Feed\GoogleFeedGenerator</item>
+                <item name="tab-style.commerce" xsi:type="object">TurnTo\SocialCommerce\Service\Feed\CommerceFeedGenerator</item>
+            </argument>
+        </arguments>
+    </type>
     <type name="Magento\Catalog\Block\Product\View\Description">
         <plugin name="removeQuestionsTab" type="TurnTo\SocialCommerce\Plugin\Catalog\Block\Product\View\Description" />
     </type>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -24,8 +24,8 @@
     <type name="TurnTo\SocialCommerce\Service\Feed\FeedGeneratorFactory">
         <arguments>
             <argument name="generators" xsi:type="array">
-                <item name="google-product.xml" xsi:type="object">TurnTo\SocialCommerce\Service\Feed\GoogleFeedGenerator</item>
-                <item name="tab-style.commerce" xsi:type="object">TurnTo\SocialCommerce\Service\Feed\CommerceFeedGenerator</item>
+                <item name="google-product.xml" xsi:type="object">TurnTo\SocialCommerce\Service\Feed\GoogleFeedGeneratorFactory</item>
+                <item name="tab-style.commerce" xsi:type="object">TurnTo\SocialCommerce\Service\Feed\CommerceFeedGeneratorFactory</item>
             </argument>
         </arguments>
     </type>

--- a/view/frontend/templates/product/view/reviews-tab.phtml
+++ b/view/frontend/templates/product/view/reviews-tab.phtml
@@ -26,10 +26,9 @@ $viewModel = $block->getViewModel();
                             "component": "TurnTo_SocialCommerce/js/reviews-tab",
                             "config": {
                                 "siteKey": "<?= $viewModel->getSiteKey() ?>",
-                                "reviewSku": "<?= $viewModel->turnToSafeEncoding($viewModel->getProductSku()) ?>",
+                                "reviewSku": "<?= $viewModel->getProductSku() ?>",
                                 "reviewsEnabled": "<?= $viewModel->getConfigBool(Config::REVIEWS_ENABLE) ? 'true' : 'false' ?>",
                                 "reviewsUrl": "<?= $viewModel->getConfigValue(Config::PRODUCT_REVIEW_URL) ?>"
-
                             }
                         }
                     }

--- a/view/frontend/templates/product/view/teaser-conditional.phtml
+++ b/view/frontend/templates/product/view/teaser-conditional.phtml
@@ -27,7 +27,7 @@ $viewModel = $block->getViewModel();
                                 "component": "TurnTo_SocialCommerce/js/teaser",
                                 "config": {
                                     "siteKey": "<?= $viewModel->getSiteKey() ?>",
-                                    "teaserSku": "<?= $viewModel->turnToSafeEncoding($block->getProduct()->getSku()) ?>",
+                                    "teaserSku": "<?= $viewModel->getProductSku() ?>",
                                     "reviewsEnabled": "<?= $viewModel->getConfigBool(Config::REVIEWS_ENABLE) ? 'true' : 'false' ?>",
                                     "reviewsTeaserEnabled": "<?= $viewModel->getConfigBool(Config::TEASER_REVIEWS_TEASER_ENABLE) ? 'true' : 'false' ?>",
                                     "qaEnabled": "<?= $viewModel->getConfigBool(Config::QA_ENABLE) ? 'true' : 'false' ?>",


### PR DESCRIPTION
[TSD-415](https://emplifi.atlassian.net/browse/TSD-415): Implement Commerce Catalog Feed & Improve Export Logic

### Summary
This PR introduces support for the Commerce Catalog Feed format. It adds a configuration option allowing merchants to select between the existing Google feed format and the new Commerce feed format. Additionally, this update improves product URL resolution logic and introduces the members field to support review sharing for bundle and grouped product types.

### Key Changes

- Feed Format Selection: Added a new configuration setting to toggle between Google and Commerce feed formats.
- Commerce Feed Generator: Implemented CommerceFeedGenerator to handle the specific formatting and column requirements of the Commerce feed.
- Members Column for Review Sharing: Added a members field to the Commerce feed. This field outputs a comma-separated list of child SKUs for Bundle and Grouped products, enabling TurnTo to properly share reviews between the collection and its individual simple products.
- Improved Product URL Logic: Refactored URL resolution in Model/Export/Product.php to better handle store-specific URLs and preloaded rewrites.
- Code Refactoring: Abstracted common feed generation logic into AbstractFeedGenerator to keep the Google and Commerce generators DRY.

[TSD-415]: https://emplifi.atlassian.net/browse/TSD-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the catalog feed export path to use new generator abstractions, paging/batching logic, and direct DB lookups; mistakes could affect feed completeness or URL/category correctness across stores. Adds new network retry behavior for feed submission, which changes operational characteristics under failure conditions.
> 
> **Overview**
> Adds a selectable **product feed format** (new `feed_format` system config) to generate either the existing Google Shopping Atom feed or a new **tab-delimited Commerce catalog feed**.
> 
> Refactors `Model/Export/Catalog::cronUploadFeed()` to stream feeds via a `FeedGeneratorInterface` (factory-selected by format), batch products into multiple uploaded files, preload product URL rewrites and deepest category paths, and optimize parent/child mapping for configurables via a single DB query. Updates URL-rewrite selection to prefer canonical rewrites and adds a `CategoryPathResolver` to avoid per-product category recursion.
> 
> Improves robustness and compatibility: consistent `turnToSafeEncoding` for SKUs (widgets/configurable JSON/gallery), adds stock fields to product collection, adds feed submission retries/backoff + format-specific file logging, and introduces extensive unit tests covering new generators, factory, export flow, and retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ca912510311085a52da1e6696d05514c41df1f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->