### PR TITLE
Release/3.9.0

### DIFF
--- a/Api/FeedGeneratorInterface.php
+++ b/Api/FeedGeneratorInterface.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Api;
+
+use LogicException;
+use Magento\Store\Api\Data\StoreInterface;
+
+interface FeedGeneratorInterface
+{
+    /**
+     * Start the feed generation process.
+     *
+     * @param StoreInterface $store
+     * @return void
+     */
+    public function beginFeed(StoreInterface $store);
+
+    /**
+     * Add a product to the feed.
+     *
+     * @param mixed $product
+     * @param mixed $parent
+     * @param int|string|null $storeId
+     * @return bool True when line/item was added to the feed, false otherwise.
+     */
+    public function addProduct($product, $parent = null, $storeId = null): bool;
+
+    /**
+     * Finish the feed generation and return the feed data.
+     *
+     * @return mixed string
+     * @throws LogicException If the feed has not been initialized via beginFeed().
+     */
+    public function finishFeed();
+
+    /**
+     * Check whether the feed stream is currently open and accepting new products.
+     *
+     * @return bool
+     */
+    public function isFeedOpen(): bool;
+
+    /**
+     * Get the feed style identifier.
+     *
+     * @return string
+     */
+    public function getFeedStyle(): string;
+}

--- a/Api/JwtInterface.php
+++ b/Api/JwtInterface.php
@@ -12,7 +12,7 @@ use Exception;
 interface JwtInterface
 {
     /**
-     * @param array|object $payload
+     * @param array $payload
      * @return string
      * @throws Exception
      */

--- a/Api/SsoResponseCodeInterface.php
+++ b/Api/SsoResponseCodeInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Api;
+
+interface SsoResponseCodeInterface
+{
+    /**
+     * Payload could not be parsed or was missing required fields.
+     */
+    public const ERROR_CODE_INVALID_PAYLOAD = 'INVALID_PAYLOAD';
+
+    /**
+     * TurnTo authorization key is missing or invalid in config.
+     */
+    public const ERROR_CODE_MISSING_AUTH_KEY = 'MISSING_AUTH_KEY';
+
+    /**
+     * JWT encode failed for unexpected reasons.
+     */
+    public const ERROR_CODE_GENERATION_FAILED = 'JWT_GENERATION_FAILED';
+
+    /**
+     * SSO endpoint returned a malformed response.
+     */
+    public const ERROR_CODE_INVALID_RESPONSE = 'INVALID_RESPONSE';
+}

--- a/Block/TurnToConfig.php
+++ b/Block/TurnToConfig.php
@@ -15,6 +15,7 @@ use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use TurnTo\SocialCommerce\Api\TurnToConfigDataSourceInterface;
 use TurnTo\SocialCommerce\Model\Config as ConfigModel;
+use TurnTo\SocialCommerce\Model\Product;
 use TurnTo\SocialCommerce\Model\Version;
 
 class TurnToConfig extends Template
@@ -39,6 +40,10 @@ class TurnToConfig extends Template
      * @var Json
      */
     protected $json;
+    /**
+     * @var Product
+     */
+    protected $productModel;
 
     /**
      * @param Context $context
@@ -46,6 +51,7 @@ class TurnToConfig extends Template
      * @param ResolverInterface $localeResolver
      * @param Data $helper
      * @param Version $version
+     * @param Product $productModel
      * @param Json $json
      * @param array $data
      */
@@ -55,6 +61,7 @@ class TurnToConfig extends Template
         ResolverInterface $localeResolver,
         Data $helper,
         Version $version,
+        Product $productModel,
         Json $json,
         array $data = []
     ) {
@@ -68,6 +75,7 @@ class TurnToConfig extends Template
         $this->localeResolver = $localeResolver;
         $this->helper = $helper;
         $this->version = $version;
+        $this->productModel = $productModel;
         $this->json = $json;
     }
 
@@ -101,7 +109,7 @@ class TurnToConfig extends Template
         if ($this->config->getConfigBool(ConfigModel::VISUAL_CONTENT_ENABLE_GALLERY_ROW)) {
             $product = $this->helper->getProduct();
             if ($product) {
-                $skus = [$product->getSku()];
+                $skus = [$this->productModel->turnToSafeEncoding($product->getSku())];
                 $additionalConfigData['gallery'] = ['skus' => $skus];
             }
         }

--- a/Block/TurnToConfig.php
+++ b/Block/TurnToConfig.php
@@ -92,11 +92,8 @@ class TurnToConfig extends Template
             $configData = $configData->getData();
         }
 
-        $additionalConfigData['baseUrl'] = $this->_storeManager->getStore()->getBaseUrl();
-        $additionalConfigData['siteKey' ] = $this->config->getSiteKey();
-        $additionalConfigData = ['locale' => $this->localeResolver->getLocale()];
+        $additionalConfigData['locale'] = $this->localeResolver->getLocale();
         $additionalConfigData['extensionVersion'] = ['magentoVersion'=> $this->version->getMagentoVersion(), 'turnToCart' => $this->version->getModuleVersion()];
-        $additionalConfigData['baseUrl'] = $this->_storeManager->getStore()->getBaseUrl();
         $additionalConfigData['sso'] = ['userDataFn' => null];
 
         if ($this->config->getConfigBool(ConfigModel::QA_ENABLE)) {
@@ -147,6 +144,7 @@ class TurnToConfig extends Template
     /**
      * @param $path
      * @return mixed|null
+     * @deprecated Use ViewModel
      */
     public function getConfigValue($path)
     {
@@ -155,6 +153,7 @@ class TurnToConfig extends Template
 
     /**
      * @return string
+     * @deprecated Use ViewModel
      */
     public function getSiteKey()
     {

--- a/Block/Widget/Pinboard.php
+++ b/Block/Widget/Pinboard.php
@@ -20,6 +20,7 @@ use Magento\Rule\Model\Condition\Sql\Builder;
 use Magento\Widget\Helper\Conditions;
 use TurnTo\SocialCommerce\Block\TurnToConfig;
 use TurnTo\SocialCommerce\Model\Config;
+use TurnTo\SocialCommerce\Model\Product;
 use TurnTo\SocialCommerce\Model\Data\PinboardConfigFactory;
 
 class Pinboard extends ProductsList
@@ -32,6 +33,10 @@ class Pinboard extends ProductsList
      * @var PinboardConfigFactory
      */
     protected $pinboardConfigFactory;
+    /**
+     * @var Product
+     */
+    protected $product;
 
     /**
      * @param Config $config
@@ -49,6 +54,7 @@ class Pinboard extends ProductsList
     public function __construct(
         Config $config,
         PinboardConfigFactory $pinboardConfigFactory,
+        Product $product,
         Context $context,
         CollectionFactory $productCollectionFactory,
         Visibility $catalogProductVisibility,
@@ -61,6 +67,7 @@ class Pinboard extends ProductsList
     ) {
         $this->config = $config;
         $this->pinboardConfigFactory = $pinboardConfigFactory;
+        $this->product = $product;
         parent::__construct(
             $context,
             $productCollectionFactory,
@@ -114,7 +121,11 @@ class Pinboard extends ProductsList
     public function getProductSkus()
     {
         $productSkus = $this->getData('skus');
-        return $productSkus ? array_map('trim' , explode(',', $productSkus)) : [];
+        if (!$productSkus) {
+            return [];
+        }
+
+        return array_map([$this->product, 'turnToSafeEncoding'], array_map('trim', explode(',', $productSkus)));
     }
 
     /**

--- a/Controller/SSO/GetUserStatus.php
+++ b/Controller/SSO/GetUserStatus.php
@@ -8,14 +8,18 @@ declare(strict_types=1);
 namespace TurnTo\SocialCommerce\Controller\SSO;
 
 use Exception;
+use InvalidArgumentException;
 use Magento\Customer\Model\Session;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Controller\ResultInterface;
+use TurnTo\SocialCommerce\Logger\Monolog;
+use RuntimeException;
+use TurnTo\SocialCommerce\Api\SsoResponseCodeInterface;
 use TurnTo\SocialCommerce\Api\JwtInterface;
 
-class GetUserStatus extends Action
+class GetUserStatus extends Action implements SsoResponseCodeInterface
 {
     /**
      * @var Session
@@ -31,6 +35,10 @@ class GetUserStatus extends Action
      * @var JwtInterface
      */
     protected $jwt;
+    /**
+     * @var Monolog
+     */
+    protected $logger;
 
     /**
      * GetUserStatus constructor.
@@ -38,16 +46,19 @@ class GetUserStatus extends Action
      * @param ResultFactory $resultFactory
      * @param Session $customerSession
      * @param JwtInterface $jwt
+     * @param Monolog $logger
      */
     public function __construct(
         Context $context,
         ResultFactory $resultFactory,
         Session $customerSession,
-        JwtInterface $jwt
+        JwtInterface $jwt,
+        Monolog $logger
     ) {
         $this->customerSession = $customerSession;
         $this->resultFactory = $resultFactory;
         $this->jwt = $jwt;
+        $this->logger = $logger;
         parent::__construct($context);
     }
 
@@ -56,14 +67,18 @@ class GetUserStatus extends Action
      * https://docs.turnto.com/en/speedflex-widget-implementation/authentication/speedflex-single-sign-on--sso--integration.html#step-2--confirm-a-user-s-logged-in-status-or-provide-a-registration-or-login-form
      *
      * @return ResultInterface
-     * @throws Exception
      */
     public function execute()
     {
-        $jwt = null;
+        $response = [
+            'success' => true,
+            'logged_in' => false,
+            'jwt' => null
+        ];
         $customer = $this->customerSession->getCustomer();
 
         if ($customer->getId()) {
+            $response['logged_in'] = true;
             $customerData = [
                 'payload' => [
                     'ua' => $customer->getId(),
@@ -75,11 +90,46 @@ class GetUserStatus extends Action
                 ]
             ];
 
-            $jwt = $this->jwt->getJwt($customerData['payload']);
+            try {
+                $response['jwt'] = $this->jwt->getJwt($customerData['payload']);
+            } catch (InvalidArgumentException $e) {
+                $this->logger->error('Failed to build SSO JWT payload for user status response', [
+                    'customer_id' => $customer->getId(),
+                    'error_code' => self::ERROR_CODE_INVALID_PAYLOAD,
+                    'exception' => $e
+                ]);
+                $response['success'] = false;
+                $response['error'] = [
+                    'code' => self::ERROR_CODE_INVALID_PAYLOAD,
+                    'message' => 'Unable to build SSO payload'
+                ];
+            } catch (RuntimeException $e) {
+                $this->logger->error('Failed to generate SSO JWT for user status response', [
+                    'customer_id' => $customer->getId(),
+                    'error_code' => self::ERROR_CODE_MISSING_AUTH_KEY,
+                    'exception' => $e
+                ]);
+                $response['success'] = false;
+                $response['error'] = [
+                    'code' => self::ERROR_CODE_MISSING_AUTH_KEY,
+                    'message' => 'Missing TurnTo authorization key'
+                ];
+            } catch (Exception $e) {
+                $this->logger->error('Failed to generate SSO JWT for user status response', [
+                    'customer_id' => $customer->getId(),
+                    'error_code' => self::ERROR_CODE_GENERATION_FAILED,
+                    'exception' => $e
+                ]);
+                $response['success'] = false;
+                $response['error'] = [
+                    'code' => self::ERROR_CODE_GENERATION_FAILED,
+                    'message' => 'Unable to generate SSO token'
+                ];
+            }
         }
 
         $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
-        $resultJson->setData(['jwt' => $jwt]);
+        $resultJson->setData($response);
 
         return $resultJson;
     }

--- a/Controller/SSO/LogOutSSO.php
+++ b/Controller/SSO/LogOutSSO.php
@@ -60,7 +60,8 @@ class LogOutSSO extends Logout
     public function execute()
     {
         $lastCustomerId = $this->session->getId();
-        $this->session->logout()->setBeforeAuthUrl($this->_redirect->getRefererUrl())
+        $refererUrl = $this->_redirect->getRefererUrl();
+        $this->session->logout()->setBeforeAuthUrl($refererUrl)
             ->setLastCustomerId($lastCustomerId);
         if ($this->cookieManager->getCookie('mage-cache-sessid')) {
             $metadata = $this->cookieMetadataFactory->createCookieMetadata();
@@ -69,7 +70,7 @@ class LogOutSSO extends Logout
         }
 
         $resultRedirect = $this->resultRedirectFactory->create();
-        $resultRedirect->setPath($this->_redirect->getRefererUrl());
+        $resultRedirect->setUrl($refererUrl);
         return $resultRedirect;
     }
 }

--- a/Controller/SSO/LoggedInData.php
+++ b/Controller/SSO/LoggedInData.php
@@ -8,14 +8,18 @@ declare(strict_types=1);
 namespace TurnTo\SocialCommerce\Controller\SSO;
 
 use Exception;
+use InvalidArgumentException;
 use Magento\Customer\Model\Session;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Controller\ResultInterface;
+use TurnTo\SocialCommerce\Logger\Monolog;
+use RuntimeException;
+use TurnTo\SocialCommerce\Api\SsoResponseCodeInterface;
 use TurnTo\SocialCommerce\Api\JwtInterface;
 
-class LoggedInData  extends Action
+class LoggedInData  extends Action implements SsoResponseCodeInterface
 {
     /**
      * @var Session
@@ -31,6 +35,10 @@ class LoggedInData  extends Action
      * @var JwtInterface
      */
     protected $jwt;
+    /**
+     * @var Monolog
+     */
+    protected $logger;
 
     /**
      * GetUserStatus constructor.
@@ -38,16 +46,19 @@ class LoggedInData  extends Action
      * @param ResultFactory $resultFactory
      * @param Session $customerSession
      * @param JwtInterface $jwt
+     * @param Monolog $logger
      */
     public function __construct(
         Context $context,
         ResultFactory $resultFactory,
         Session $customerSession,
-        JwtInterface $jwt
+        JwtInterface $jwt,
+        Monolog $logger
     ) {
         $this->customerSession = $customerSession;
         $this->resultFactory = $resultFactory;
         $this->jwt = $jwt;
+        $this->logger = $logger;
         parent::__construct($context);
     }
 
@@ -56,14 +67,18 @@ class LoggedInData  extends Action
      * https://docs.turnto.com/en/speedflex-widget-implementation/authentication/speedflex-single-sign-on--sso--integration.html
      *
      * @return ResultInterface
-     * @throws Exception
      */
     public function execute()
     {
-        $jwt = null;
+        $response = [
+            'success' => true,
+            'logged_in' => false,
+            'jwt' => null
+        ];
         $customer = $this->customerSession->getCustomer();
 
         if ($customer->getId()) {
+            $response['logged_in'] = true;
             $customerData = [
                 'payload' => [
                     'ua' => $customer->getId(),
@@ -72,11 +87,46 @@ class LoggedInData  extends Action
                 ]
             ];
 
-            $jwt = $this->jwt->getJwt($customerData['payload']);
+            try {
+                $response['jwt'] = $this->jwt->getJwt($customerData['payload']);
+            } catch (InvalidArgumentException $e) {
+                $this->logger->error('Failed to build SSO JWT payload for logged-in data response', [
+                    'customer_id' => $customer->getId(),
+                    'error_code' => self::ERROR_CODE_INVALID_PAYLOAD,
+                    'exception' => $e
+                ]);
+                $response['success'] = false;
+                $response['error'] = [
+                    'code' => self::ERROR_CODE_INVALID_PAYLOAD,
+                    'message' => 'Unable to build SSO payload'
+                ];
+            } catch (RuntimeException $e) {
+                $this->logger->error('Failed to generate SSO JWT for logged-in data response', [
+                    'customer_id' => $customer->getId(),
+                    'error_code' => self::ERROR_CODE_MISSING_AUTH_KEY,
+                    'exception' => $e
+                ]);
+                $response['success'] = false;
+                $response['error'] = [
+                    'code' => self::ERROR_CODE_MISSING_AUTH_KEY,
+                    'message' => 'Missing TurnTo authorization key'
+                ];
+            } catch (Exception $e) {
+                $this->logger->error('Failed to generate SSO JWT for logged-in data response', [
+                    'customer_id' => $customer->getId(),
+                    'error_code' => self::ERROR_CODE_GENERATION_FAILED,
+                    'exception' => $e
+                ]);
+                $response['success'] = false;
+                $response['error'] = [
+                    'code' => self::ERROR_CODE_GENERATION_FAILED,
+                    'message' => 'Unable to generate SSO token'
+                ];
+            }
         }
 
         $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
-        $resultJson->setData(['jwt' => $jwt]);
+        $resultJson->setData($response);
 
         return $resultJson;
     }

--- a/Controller/SSO/RedirectToLogin.php
+++ b/Controller/SSO/RedirectToLogin.php
@@ -46,7 +46,7 @@ class RedirectToLogin extends Action
             ['referer' => base64_encode($url)]
         );
         $resultRedirect = $this->resultRedirectFactory->create();
-        $resultRedirect->setPath($login_url);
+        $resultRedirect->setUrl($login_url);
         if (!empty($message = $this->getMessage())) {
             $this->messageManager->addNoticeMessage($message);
         }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -41,6 +41,7 @@ class Config
     public const CHECKOUT_CUSTOMER_NAME_FALLBACK = 'turnto_socialcommerce_configuration/checkout_comments/js_order_feed_customer_name_fallback';
 
     public const PRODUCT_ENABLE_AUTOMATIC_SUBMISSION = 'turnto_socialcommerce_configuration/product_feed/enable_automatic_submission';
+    public const PRODUCT_FEED_FORMAT = 'turnto_socialcommerce_configuration/product_feed/feed_format';
     public const PRODUCT_FEED_URL = 'turnto_socialcommerce_configuration/product_feed/product_feed_url';
     public const PRODUCT_FEED_SUBMISSION_URL = 'turnto_socialcommerce_configuration/product_feed/feed_submission_url';
     public const PRODUCT_REVIEW_URL = 'turnto_socialcommerce_configuration/product_feed/review_api_url';
@@ -180,5 +181,15 @@ class Config
     public function getUseChildSku($scopeCode = null, $scopeType = ScopeInterface::SCOPE_STORES)
     {
         return $this->getConfigBool(self::GENERAL_USE_CHILD_SKU, $scopeCode, $scopeType);
+    }
+
+    /**
+     * @param string|int|null $scopeCode
+     * @param string $scopeType
+     * @return string|null
+     */
+    public function getFeedFormat($scopeCode = null, $scopeType = ScopeInterface::SCOPE_STORES)
+    {
+        return $this->getConfigValue(self::PRODUCT_FEED_FORMAT, $scopeCode, $scopeType);
     }
 }

--- a/Model/Config/Source/FeedFormat.php
+++ b/Model/Config/Source/FeedFormat.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class FeedFormat implements OptionSourceInterface
+{
+    public const GOOGLE_PRODUCT = 'google-product.xml';
+    public const COMMERCE = 'tab-style.commerce';
+
+    /**
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return [
+            ['value' => self::GOOGLE_PRODUCT, 'label' => __('Google Products Atom 1.0')],
+            ['value' => self::COMMERCE, 'label' => __('Commerce Product Catalog Feed')]
+        ];
+    }
+}

--- a/Model/Config/Source/ProductAttributeSelect.php
+++ b/Model/Config/Source/ProductAttributeSelect.php
@@ -8,8 +8,8 @@ namespace TurnTo\SocialCommerce\Model\Config\Source;
 
 use Magento\Catalog\Api\Data\ProductAttributeInterface;
 use Magento\Eav\Api\AttributeRepositoryInterface;
-use Magento\Framework\Api\SearchCriteriaBuilder;
-use Magento\Framework\Api\SortOrderBuilder;
+use Magento\Framework\Api\SearchCriteriaBuilderFactory;
+use Magento\Framework\Api\SortOrderBuilderFactory;
 use Magento\Framework\Data\OptionSourceInterface;
 
 /**
@@ -23,27 +23,27 @@ class ProductAttributeSelect implements OptionSourceInterface
      */
     protected $attributeRepository;
     /**
-     * @var SearchCriteriaBuilder
+     * @var SearchCriteriaBuilderFactory
      */
-    protected $searchCriteriaBuilder;
+    protected $searchCriteriaBuilderFactory;
     /**
-     * @var SortOrderBuilder
+     * @var SortOrderBuilderFactory
      */
-    protected $sortOrderBuilder;
+    protected $sortOrderBuilderFactory;
 
     /**
      * @param AttributeRepositoryInterface $attributeRepository
-     * @param SearchCriteriaBuilder $searchCriteriaBuilder
-     * @param SortOrderBuilder $sortOrderBuilder
+     * @param SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory
+     * @param SortOrderBuilderFactory $sortOrderBuilderFactory
      */
     public function __construct(
         AttributeRepositoryInterface $attributeRepository,
-        SearchCriteriaBuilder $searchCriteriaBuilder,
-        SortOrderBuilder $sortOrderBuilder
+        SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory,
+        SortOrderBuilderFactory $sortOrderBuilderFactory
     ) {
         $this->attributeRepository = $attributeRepository;
-        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
-        $this->sortOrderBuilder = $sortOrderBuilder;
+        $this->searchCriteriaBuilderFactory = $searchCriteriaBuilderFactory;
+        $this->sortOrderBuilderFactory = $sortOrderBuilderFactory;
     }
 
     /**
@@ -59,9 +59,10 @@ class ProductAttributeSelect implements OptionSourceInterface
             ]
         ];
 
-        $sortOrder = $this->sortOrderBuilder->setField('frontend_label')->setAscendingDirection()->create();
+        $sortOrder = $this->sortOrderBuilderFactory->create()
+            ->setField('frontend_label')->setAscendingDirection()->create();
         // Filter out system only attributes e.g. created_at, entity_id, etc.
-        $searchCriteria = $this->searchCriteriaBuilder
+        $searchCriteria = $this->searchCriteriaBuilderFactory->create()
             ->addFilter('frontend_label', null, 'neq')
             ->addSortOrder($sortOrder)
             ->create();

--- a/Model/Export/CanceledOrders.php
+++ b/Model/Export/CanceledOrders.php
@@ -12,6 +12,8 @@ use DateTime;
 use DateTimeZone;
 use Exception;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem\Io\File;
 use Magento\Framework\Intl\DateTimeFactory;
 use Magento\Sales\Model\ResourceModel\Order\Collection;
@@ -26,6 +28,7 @@ class CanceledOrders
 {
     const FEED_NAME = 'canceled-orders-feed.tsv';
     const FEED_STYLE = 'cancelled-order.txt';
+    protected const LOOKBACK_INTERVAL = 'P2D';
     /**
      * @var Config
      */
@@ -110,16 +113,17 @@ class CanceledOrders
      * @param DateTime $fromDate
      * @param DateTime $toDate
      * @param bool $forceIncludeAllItems
-     *
-     * @return bool|string|null
+     * @return string
+     * @throws FileSystemException
+     * @throws LocalizedException
      */
     public function getCanceledOrdersFeed(
         $storeId,
         DateTime $fromDate,
         DateTime $toDate,
         bool $forceIncludeAllItems = false
-    ) {
-        $csvData = null;
+    ): string {
+        $outputHandle = null;
         $canceledOrders = $this->getCanceledOrders($storeId, $fromDate, $toDate);
 
         try {
@@ -127,27 +131,27 @@ class CanceledOrders
 
             $outputFile = $this->directoryList->getPath(DirectoryList::TMP) . '/' . self::FEED_NAME;
             $outputHandle = fopen($outputFile, 'w+');
+            if ($outputHandle === false) {
+                throw new LocalizedException(__('Unable to open temporary file.'));
+            }
             fputcsv(
                 $outputHandle,
                 [
                     'ORDERID',
                     'SKU'
                 ],
-                "\t"
+                "\t",
+                '"',
+                "\\"
             );
             $this->writeOrdersToFeed($outputHandle, $canceledOrders, $forceIncludeAllItems);
             rewind($outputHandle);
             $csvData = stream_get_contents($outputHandle);
-        } catch (Exception $e) {
-            $this->logger->error(
-                'An error occurred while creating or writing to the Historical Orders Feed export file',
-                [
-                    'storeId' => $storeId,
-                    'exception' => $e
-                ]
-            );
+            if ($csvData === false || $csvData === '') {
+                throw new LocalizedException(__('Invalid CSV data'));
+            }
         } finally {
-            if (isset($outputHandle)) {
+            if (is_resource($outputHandle)) {
                 fclose($outputHandle);
             }
         }
@@ -163,12 +167,13 @@ class CanceledOrders
     {
         foreach ($this->storeManager->getStores() as $store) {
             if ($this->config->getIsEnabled($store->getCode()) &&
-                $this->config->getConfigValue(Config::ORDER_ENABLE_CANCELLED_FEED, $store->getCode())
+                $this->config->getConfigBool(Config::ORDER_ENABLE_CANCELLED_FEED, $store->getCode())
             ) {
                 try {
                     $feedData = $this->getCanceledOrdersFeed(
                         $store->getId(),
-                        $this->dateTimeFactory->create('now', new DateTimeZone('UTC'))->sub(new DateInterval('P80D')),
+                        $this->dateTimeFactory->create('now', new DateTimeZone('UTC'))
+                            ->sub(new DateInterval(static::LOOKBACK_INTERVAL)),
                         $this->dateTimeFactory->create('now', new DateTimeZone('UTC'))
                     );
                     $this->feedClient->transmitFeedFile($feedData, self::FEED_NAME, self::FEED_STYLE, $store->getCode());
@@ -197,8 +202,8 @@ class CanceledOrders
         return $this->orderCollectionFactory->create()
             ->addAttributeToFilter('status', ['eq' => 'canceled'])
             ->addAttributeToFilter(Orders::STORE_ID_FIELD_ID, ['eq' => $storeId])
-            ->addAttributeToFilter(Orders::UPDATED_AT_FIELD_ID, ['gteq' => $fromDate->format(DATE_ATOM)])
-            ->addAttributeToFilter(Orders::UPDATED_AT_FIELD_ID, ['lteq' => $toDate->format(DATE_ATOM)]);
+            ->addAttributeToFilter(Orders::UPDATED_AT_FIELD_ID, ['gteq' => $fromDate->format('Y-m-d H:i:s')])
+            ->addAttributeToFilter(Orders::UPDATED_AT_FIELD_ID, ['lteq' => $toDate->format('Y-m-d H:i:s')]);
     }
 
     /**
@@ -222,7 +227,7 @@ class CanceledOrders
                     $row[] = $order->getIncrementId();
                     $row[] = $this->product->turnToSafeEncoding($sku);
 
-                    fputcsv($outputHandle, $row, "\t");
+                    fputcsv($outputHandle, $row, "\t", '"', "\\");
                 }
             } catch (Exception $e) {
                 $this->logger->error(

--- a/Model/Export/Catalog.php
+++ b/Model/Export/Catalog.php
@@ -139,6 +139,7 @@ class Catalog
                 $emulationStarted = false;
                 $page = 1;
                 $productCount = 0;
+                $pagesInCurrentFile = 0;
                 $fileIndex = 1;
                 $generator = null;
                 $batchSize = null;
@@ -271,15 +272,20 @@ class Catalog
                         $products->clear();
                         unset($products);
 
-                        if ($productCount >= $batchSize) {
+                        $pagesInCurrentFile++;
+                        $isLastPage = ($page >= $totalPages);
+                        $pageBatchComplete = ($pagesInCurrentFile >= $pagesPerBatch);
+                        if (($pageBatchComplete || $isLastPage) && $generator->isFeedOpen()) {
                             $feedData = $generator->finishFeed();
-                            $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);
-                            $currentFeedFile = $fileName;
-
-                            $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
-
+                            $shouldTransmit = ($totalFiles > 1) || ($productCount > 0);
+                            if ($shouldTransmit) {
+                                $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);
+                                $currentFeedFile = $fileName;
+                                $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
+                                $fileIndex++;
+                            }
                             $productCount = 0;
-                            $fileIndex++;
+                            $pagesInCurrentFile = 0;
                         }
                         if ($page >= $totalPages) {
                             break;
@@ -292,14 +298,14 @@ class Catalog
                         }
                     }
 
-                    if ($generator->isFeedOpen() && $productCount > 0) {
+                    if ($generator->isFeedOpen()) {
                         $feedData = $generator->finishFeed();
-                        $totalFiles = ceil($this->totalPages / $pagesPerBatch);
-                        $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);
-                        $currentFeedFile = $fileName;
-                        $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
-                    } elseif ($generator->isFeedOpen()) {
-                        $generator->finishFeed();
+                        $shouldTransmit = ($totalFiles > 1) || ($productCount > 0);
+                        if ($shouldTransmit) {
+                            $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);
+                            $currentFeedFile = $fileName;
+                            $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
+                        }
                     }
                 } catch (Exception $e) {
                     if ($generator !== null && $generator->isFeedOpen()) {

--- a/Model/Export/Catalog.php
+++ b/Model/Export/Catalog.php
@@ -141,6 +141,8 @@ class Catalog
                 $productCount = 0;
                 $fileIndex = 1;
                 $generator = null;
+                $batchSize = null;
+                $currentFeedFile = null;
                 try {
                     $feedFormat = $this->config->getFeedFormat($storeId);
                     $siteKey = $this->config->getSiteKey($storeId);
@@ -187,126 +189,98 @@ class Catalog
                     $totalFiles = $totalPages > 0 ? ceil($totalPages / $pagesPerBatch) : 0;
 
                     while (true) {
-                        try {
-                            $productIds = [];
-                            foreach ($products as $product) {
-                                $productIds[] = $product->getId();
-                            }
-
-                            $childProducts = [];
-                            if ($this->config->getUseChildSku($storeId)) {
-                                $simpleIds = [];
-                                foreach ($products as $product) {
-                                    if ($product->getTypeId() !== Configurable::TYPE_CODE) {
-                                        $simpleIds[] = $product->getId();
-                                    }
-                                }
-
-                                if (!empty($simpleIds)) {
-                                    $connection = $this->resourceConnection->getConnection();
-                                    $select = $connection->select()
-                                        ->from(['l' => $connection->getTableName('catalog_product_super_link')], ['parent_id', 'product_id'])
-                                        ->join(['pe' => $connection->getTableName('catalog_product_entity')], 'pe.entity_id = l.parent_id', ['parent_sku' => 'sku'])
-                                        ->where('l.product_id IN (?)', $simpleIds);
-                                    $rows = $connection->fetchAll($select);
-
-                                    if (!empty($rows)) {
-                                        $parentMap = [];
-                                        $emptyCollection = $this->productCollectionFactory->create();
-                                        $parentIds = array_values(array_unique(array_map('intval', array_column($rows, 'parent_id'))));
-                                        $parentCollection = $this->productCollectionFactory->create();
-                                        $parentCollection->setStoreId($storeId)
-                                            ->addAttributeToSelect(['url_key', 'url_path'])
-                                            ->addFieldToFilter('entity_id', ['in' => $parentIds]);
-                                        $loadedParentProducts = [];
-                                        foreach ($parentCollection as $parentProduct) {
-                                            $loadedParentProducts[(int) $parentProduct->getId()] = $parentProduct;
-                                        }
-
-                                        foreach ($rows as $row) {
-                                            $parentId = (int) $row['parent_id'];
-
-                                            if (!isset($parentMap[$parentId])) {
-                                                if (isset($loadedParentProducts[$parentId])) {
-                                                    $parentProduct = $loadedParentProducts[$parentId];
-                                                } else {
-                                                    $parentProduct = $emptyCollection->getNewEmptyItem();
-                                                    $parentProduct->setData([
-                                                        'entity_id' => $parentId,
-                                                        'sku' => $row['parent_sku'],
-                                                        'type_id' => 'configurable',
-                                                        'store_id' => $storeId
-                                                    ]);
-                                                }
-
-                                                $parentMap[$parentId] = $parentProduct;
-                                            }
-
-                                            $childProducts[(int) $row['product_id']] = $parentMap[$parentId];
-                                        }
-
-                                        $productIds = array_merge($productIds, $parentIds);
-
-                                        unset($emptyCollection, $parentMap);
-                                    }
-                                }
-                            }
-
-                            $categoryProductIds = $productIds;
-                            $this->exportProduct->preloadRewriteUrls($storeId, $productIds);
-                            $this->categoryPathResolver->preloadCategoryPaths($storeId, $categoryProductIds);
-
-                            if (!$generator->isFeedOpen()) {
-                                $generator->beginFeed($store);
-                            }
-
-                            foreach ($products as $product) {
-                                $parent = isset($childProducts[(int) $product->getId()]) ? $childProducts[(int) $product->getId()] : false;
-                                if ($generator->addProduct($product, $parent, $storeId)) {
-                                    $productCount++;
-                                }
-                            }
-
-                            $products->clear();
-                            unset($products);
-
-                            if ($productCount >= $batchSize) {
-                                $feedData = $generator->finishFeed();
-                                $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);
-
-                                try {
-                                    $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
-                                } catch (Exception $e) {
-                                    $this->logger->error(
-                                        'TurnTo catalog export transmit file error',
-                                        [
-                                            'store_id' => $storeId,
-                                            'file_name' => $fileName,
-                                            'page' => $page,
-                                            'batch_size' => $batchSize,
-                                            'file_index' => $fileIndex,
-                                            'exception' => $e
-                                        ]
-                                    );
-                                    throw $e;
-                                }
-
-                                $productCount = 0;
-                                $fileIndex++;
-                            }
-                        } catch (Exception $e) {
-                            $this->logger->error(
-                                'TurnTo catalog export error sending page',
-                                [
-                                    'store_id' => $storeId,
-                                    'store_code' => $store->getCode(),
-                                    'page' => $page ?? null,
-                                    'exception' => $e
-                                ]
-                            );
-                            throw $e;
+                        $productIds = [];
+                        foreach ($products as $product) {
+                            $productIds[] = $product->getId();
                         }
 
+                        $childProducts = [];
+                        if ($this->config->getUseChildSku($storeId)) {
+                            $simpleIds = [];
+                            foreach ($products as $product) {
+                                if ($product->getTypeId() !== Configurable::TYPE_CODE) {
+                                    $simpleIds[] = $product->getId();
+                                }
+                            }
+
+                            if (!empty($simpleIds)) {
+                                $connection = $this->resourceConnection->getConnection();
+                                $select = $connection->select()
+                                    ->from(['l' => $connection->getTableName('catalog_product_super_link')], ['parent_id', 'product_id'])
+                                    ->join(['pe' => $connection->getTableName('catalog_product_entity')], 'pe.entity_id = l.parent_id', ['parent_sku' => 'sku'])
+                                    ->where('l.product_id IN (?)', $simpleIds);
+                                $rows = $connection->fetchAll($select);
+
+                                if (!empty($rows)) {
+                                    $parentMap = [];
+                                    $emptyCollection = $this->productCollectionFactory->create();
+                                    $parentIds = array_values(array_unique(array_map('intval', array_column($rows, 'parent_id'))));
+                                    $parentCollection = $this->productCollectionFactory->create();
+                                    $parentCollection->setStoreId($storeId)
+                                        ->addAttributeToSelect(['url_key', 'url_path'])
+                                        ->addFieldToFilter('entity_id', ['in' => $parentIds]);
+                                    $loadedParentProducts = [];
+                                    foreach ($parentCollection as $parentProduct) {
+                                        $loadedParentProducts[(int) $parentProduct->getId()] = $parentProduct;
+                                    }
+
+                                    foreach ($rows as $row) {
+                                        $parentId = (int) $row['parent_id'];
+
+                                        if (!isset($parentMap[$parentId])) {
+                                            if (isset($loadedParentProducts[$parentId])) {
+                                                $parentProduct = $loadedParentProducts[$parentId];
+                                            } else {
+                                                $parentProduct = $emptyCollection->getNewEmptyItem();
+                                                $parentProduct->setData([
+                                                    'entity_id' => $parentId,
+                                                    'sku' => $row['parent_sku'],
+                                                    'type_id' => 'configurable',
+                                                    'store_id' => $storeId
+                                                ]);
+                                            }
+
+                                            $parentMap[$parentId] = $parentProduct;
+                                        }
+
+                                        $childProducts[(int) $row['product_id']] = $parentMap[$parentId];
+                                    }
+
+                                    $productIds = array_merge($productIds, $parentIds);
+
+                                    unset($emptyCollection, $parentMap);
+                                }
+                            }
+                        }
+
+                        $categoryProductIds = $productIds;
+                        $this->exportProduct->preloadRewriteUrls($storeId, $productIds);
+                        $this->categoryPathResolver->preloadCategoryPaths($storeId, $categoryProductIds);
+
+                        if (!$generator->isFeedOpen()) {
+                            $generator->beginFeed($store);
+                        }
+
+                        foreach ($products as $product) {
+                            $parent = isset($childProducts[(int) $product->getId()]) ? $childProducts[(int) $product->getId()] : false;
+                            if ($generator->addProduct($product, $parent, $storeId)) {
+                                $productCount++;
+                            }
+                        }
+
+                        $products->clear();
+                        unset($products);
+
+                        if ($productCount >= $batchSize) {
+                            $feedData = $generator->finishFeed();
+                            $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);
+                            $currentFeedFile = $fileName;
+
+                            $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
+
+                            $productCount = 0;
+                            $fileIndex++;
+                        }
                         if ($page >= $totalPages) {
                             break;
                         }
@@ -322,19 +296,8 @@ class Catalog
                         $feedData = $generator->finishFeed();
                         $totalFiles = ceil($this->totalPages / $pagesPerBatch);
                         $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);
-                        try {
-                            $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
-                        } catch (Exception $e) {
-                            $this->logger->error(
-                                'TurnTo catalog export transmit file error',
-                                [
-                                    'store_id' => $storeId,
-                                    'file_name' => $fileName,
-                                    'exception' => $e
-                                ]
-                            );
-                            throw $e;
-                        }
+                        $currentFeedFile = $fileName;
+                        $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
                     } elseif ($generator->isFeedOpen()) {
                         $generator->finishFeed();
                     }
@@ -360,6 +323,9 @@ class Catalog
                             'exception' => $e,
                             'store_id' => $storeId,
                             'store_code' => $store->getCode(),
+                            'page' => $page,
+                            'file_name' => $currentFeedFile,
+                            'batch_size' => $batchSize
                         ]
                     );
                 } finally {

--- a/Model/Export/Catalog.php
+++ b/Model/Export/Catalog.php
@@ -7,60 +7,34 @@ declare(strict_types=1);
 
 namespace TurnTo\SocialCommerce\Model\Export;
 
-use DateTimeZone;
 use Exception;
-use Magento\Catalog\Api\Data\ProductAttributeInterface;
-use Magento\Catalog\Helper\Image;
-use Magento\Catalog\Model\Category;
-use Magento\Catalog\Model\Product as CatalogProduct;
-use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Catalog\Model\Product\Visibility;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Framework\App\Area;
+use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Framework\Intl\DateTimeFactory;
-use Magento\Framework\Pricing\PriceCurrencyInterface;
-use Magento\Framework\UrlInterface;
-use Magento\Eav\Model\Config as EavConfig;
-use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\App\Emulation;
-use SimpleXMLElement;
 use TurnTo\SocialCommerce\Api\FeedClient;
+use TurnTo\SocialCommerce\Logger\Monolog;
 use TurnTo\SocialCommerce\Model\Config;
 use TurnTo\SocialCommerce\Model\Config\Gtin;
-use TurnTo\SocialCommerce\Model\Product;
-use TurnTo\SocialCommerce\Logger\Monolog;
+use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
+use TurnTo\SocialCommerce\Model\Export\CategoryPathResolver;
+use TurnTo\SocialCommerce\Model\Export\Product as ExportProduct;
+use TurnTo\SocialCommerce\Service\Feed\FeedGeneratorFactory;
 
 /**
- * Class Catalog
- * @package TurnTo\SocialCommerce\Model\Export
+ * Export Catalog
  */
 class Catalog
 {
     /**
-     * Feed Style used for the Product Feed
+     * @var FeedGeneratorFactory
      */
-    const FEED_STYLE = 'google-product.xml';
-
-    /**
-     * @var Image $imageHelper
-     */
-    protected $imageHelper = null;
-
-    /**
-     * @var Product
-     */
-    protected $product;
-
-    /**
-     * Used to generate file name (x_of_totalPages_feed.xml)
-     * @var Int
-     */
-    protected $totalPages;
+    protected $feedGeneratorFactory;
     /**
      * @var StoreManagerInterface
      */
@@ -82,25 +56,31 @@ class Catalog
      */
     protected $productCollectionFactory;
     /**
-     * @var DateTimeFactory
-     */
-    protected $dateTimeFactory;
-    /**
      * @var Gtin
      */
     protected $gtinConfig;
-    /**
-     * @var EavConfig
-     */
-    protected $eavConfig;
     /**
      * @var Emulation
      */
     protected $emulation;
     /**
-     * @var PriceCurrencyInterface
+     * @var ResourceConnection
      */
-    protected $priceCurrency;
+    protected $resourceConnection;
+    /**
+     * @var ExportProduct
+     */
+    protected $exportProduct;
+
+    /**
+     * @var CategoryPathResolver
+     */
+    protected $categoryPathResolver;
+
+    /**
+     * @var Int
+     */
+    protected $totalPages;
 
     /**
      * Catalog constructor.
@@ -109,410 +89,38 @@ class Catalog
      * @param Gtin $gtinConfig
      * @param StoreManagerInterface $storeManager
      * @param CollectionFactory $productCollectionFactory
-     * @param DateTimeFactory $dateTimeFactory
-     * @param Image $imageHelper
-     * @param Product $product
-     * @param EavConfig $eavConfig
      * @param FeedClient $feedClient
      * @param Emulation $emulation
-     * @param PriceCurrencyInterface $priceCurrency
      * @param Monolog $logger
+     * @param FeedGeneratorFactory $feedGeneratorFactory
+     * @param ResourceConnection $resourceConnection
+     * @param ExportProduct $exportProduct
+     * @param CategoryPathResolver $categoryPathResolver
      */
     public function __construct(
         Config                $config,
         Gtin                  $gtinConfig,
         StoreManagerInterface $storeManager,
         CollectionFactory     $productCollectionFactory,
-        DateTimeFactory       $dateTimeFactory,
-        Image                 $imageHelper,
-        Product               $product,
-        EavConfig             $eavConfig,
         FeedClient            $feedClient,
         Emulation             $emulation,
-        PriceCurrencyInterface $priceCurrency,
-        Monolog               $logger
+        Monolog               $logger,
+        FeedGeneratorFactory  $feedGeneratorFactory,
+        ResourceConnection    $resourceConnection,
+        ExportProduct         $exportProduct,
+        CategoryPathResolver  $categoryPathResolver
     ) {
         $this->config = $config;
         $this->gtinConfig = $gtinConfig;
-        $this->imageHelper = $imageHelper;
         $this->storeManager = $storeManager;
-        $this->product = $product;
-        $this->eavConfig = $eavConfig;
         $this->feedClient = $feedClient;
         $this->logger = $logger;
         $this->productCollectionFactory = $productCollectionFactory;
-        $this->dateTimeFactory = $dateTimeFactory;
         $this->emulation = $emulation;
-        $this->priceCurrency = $priceCurrency;
-    }
-
-    /**
-     * Escapes special characters for xml use
-     *
-     * @param string $dirtyString
-     *
-     * @return string
-     */
-    protected function sanitizeData($dirtyString)
-    {
-        if (is_string($dirtyString)) {
-            return htmlspecialchars($dirtyString, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
-        }
-        return $dirtyString;
-    }
-
-	/**
-	 * Resolves a product attribute value, returning the display label for
-	 * EAV select/multiselect attributes instead of the raw option ID.
-	 *
-	 * @param CatalogProduct $product
-	 * @param string $attributeCode
-	 * @return string|null
-	 */
-    protected function getProductAttributeValue(CatalogProduct $product, string $attributeCode)
-    {
-        if (empty($attributeCode)) {
-            return null;
-        }
-
-        try {
-            $attribute = $this->eavConfig->getAttribute(ProductAttributeInterface::ENTITY_TYPE_CODE, $attributeCode);
-            if ($attribute && $attribute->usesSource()) {
-                $label = $product->getAttributeText($attributeCode);
-                if (is_array($label)) {
-                    return implode(', ', $label);
-                }
-                return (string)$label;
-            }
-        } catch (Exception $e) {
-            $this->logger->error(
-                'Error retrieving product attribute',
-                [
-                    'exception' => $e,
-                    'attributeCode' => $attributeCode,
-                    'productId' => $product->getId()
-                ]
-            );
-        }
-
-        $value = $product->getData($attributeCode);
-        if (is_array($value)) {
-            return implode(', ', array_map('strval', $value));
-        }
-        return !empty($value) ? (string)$value : null;
-    }
-
-    /**
-     * @param $product
-     * @param $gtinMap
-     * @return string|null
-     */
-    public function getGtinValue($product, $gtinMap)
-    {
-        $gtinAttributes = [
-            Gtin::UPC_ATTRIBUTE,
-            Gtin::EAN_ATTRIBUTE,
-            Gtin::JAN_ATTRIBUTE,
-            Gtin::ISBN_ATTRIBUTE,
-            Gtin::ASIN_ATTRIBUTE
-        ];
-        foreach ($gtinAttributes as $key) {
-            if (isset($gtinMap[$key])) {
-                return $this->getProductAttributeValue($product, $gtinMap[$key]);
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @param $product
-     * @return string
-     */
-    public function getProductImageUrl($product)
-    {
-        $productImageUrl = '';
-        try {
-            $productImage = $product->getImage();
-            if ($productImage) {
-                $productImageUrl = $this->imageHelper->init($product, 'product_page_main_image')
-                    ->setImageFile($productImage)->getUrl();
-            }
-        } catch (Exception $e) {
-            $this->logger->error(
-                'Error retrieving product image',
-                [
-                    'exception' => $e,
-                    'productId' => $product->getId()
-                ]
-            );
-        }
-
-        return $productImageUrl;
-    }
-
-    /**
-     * Writes all individually visible products to an ATOM 1.0 feed which is returned in a SimpleXMLElement Object
-     *
-     * @param StoreInterface $store
-     * @param $page
-     * @return bool|SimpleXMLElement
-     * @throws Exception If feed could not be generated
-     */
-    protected function generateProductFeed(StoreInterface $store, $page)
-    {
-        $feed = null;
-        $progressCounter = 0;
-        $products = [];
-        $storeId = $store->getId();
-
-        try {
-            if (!$products = $this->getProducts($storeId, $page)) {
-                return false;
-            }
-            $feed = new SimpleXMLElement(
-                '<?xml version="1.0" encoding="UTF-8"?>' . '<feed xmlns="http://www.w3.org/2005/Atom"' . ' xmlns:g="http://base.google.com/ns/1.0" xml:lang="en-US" />'
-            );
-
-            $feed->addChild('title', $this->sanitizeData($store->getName() . ' - Google Product Atom 1.0 Feed'));
-            $feed->addChild(
-                'link',
-                $this->sanitizeData($store->getBaseUrl(UrlInterface::URL_TYPE_LINK))
-            );
-            $feed->addChild(
-                'updated',
-                $this->dateTimeFactory->create('now', new DateTimeZone('UTC'))->format(DATE_ATOM)
-            );
-            $feed->addChild('author')->addChild('name', 'TurnTo');
-            $feed->addChild(
-                'id',
-                $this->sanitizeData($store->getBaseUrl(UrlInterface::URL_TYPE_WEB))
-            );
-
-            $childProducts = [];
-
-            // TurnTo requires a product feed where children of configurable products are aware of their parent SKUs
-            // and include that parent SKU in the feed. This code is not very performant and therefore the feed will
-            // take longer to generate in large catalogs with many configurable products. However in the interest of
-            // development time, this simpler approach is being taken and if it proves to not scale well, can be
-            // refactored in the future to use a query that loads all child products for all configurable products
-            // at one time.
-            if ($this->config->getUseChildSku($storeId)) {
-                foreach ($products as $product) {
-                    if ($product->getTypeId() !== Configurable::TYPE_CODE) {
-                        continue;
-                    }
-
-                    $children = $product->getTypeInstance()->getUsedProducts($product);
-                    foreach ($children as $child) {
-                        $childProducts[$child->getSku()] = $product;
-                    }
-                }
-            }
-
-            foreach ($products as $product) {
-                $parent = false;
-                if ($this->config->getUseChildSku($storeId) && isset($childProducts[$product->getSku()])) {
-                    $parent = $childProducts[$product->getSku()];
-                }
-                try {
-                    $this->addProductToAtomFeed($feed->addChild('entry'), $product, $storeId, $parent);
-                } catch (Exception $entryException) {
-                    $this->logger->error(
-                        'Product failed to be added to feed',
-                        [
-                            'exception' => $entryException,
-                            'productSKU' => $product->getSku()
-                        ]
-                    );
-                }
-                $progressCounter++;
-            }
-
-            return $feed;
-        } catch (Exception $e) {
-            if ($feed) {
-                $this->logger->error(
-                    'An exception occurred while generating the catalog feed',
-                    [
-                        'exception' => $e,
-                        'productCount' => count($products),
-                        'productsProcessed' => $progressCounter
-                    ]
-                );
-                throw $e;
-            }
-            if ($products) {
-                $this->logger->error(
-                    'An exception occurred that prevented the creation of the catalog feed due to invalid product data.',
-                    [
-                        'exception' => $e,
-                        'productCount' => count($products),
-                        'productsProcessed' => $progressCounter
-                    ]
-                );
-                throw $e;
-            }
-            $this->logger->error(
-                'An exception occurred while retrieving the products for the catalog feed',
-                [
-                    'exception' => $e,
-                    'productsProcessed' => $progressCounter
-                ]
-            );
-
-            throw $e;
-        }
-    }
-
-    /**
-     * Adds a Magento catalog product to a Google Products ATOM 1.0 xml feed
-     *
-     * @param SimpleXMLElement $entry
-     * @param CatalogProduct $product
-     * @param int|string $storeId
-     * @param bool|CatalogProduct $parent
-     *
-     * @throws Exception
-     */
-    protected function addProductToAtomFeed($entry, $product, $storeId, $parent)
-    {
-        if (empty($product)) {
-            throw new Exception('Product can not be null or empty');
-        }
-
-        $sku = $this->product->turnToSafeEncoding($product->getSku());
-        if (empty($sku)) {
-            throw new Exception('Product must have a valid sku');
-        }
-
-        $productUrl = $parent ? $parent->getProductUrl() : $product->getProductUrl();
-        if (empty($productUrl)) {
-            throw new Exception('Product must have a valid store-product url');
-        }
-
-        $productName = $product->getName();
-        if (empty($productName)) {
-            throw new Exception('Product must have a valid name');
-        }
-        $productName = str_replace("\n", "", $productName);
-
-        $entry->addChild('id', $this->sanitizeData($sku));
-
-        $identifierExists = 'FALSE';
-        $gtinMap = $this->gtinConfig->getGtinAttributesMap($storeId);
-        if (!empty($gtinMap)) {
-            $gtinValue = $this->getGtinValue($product, $gtinMap);
-            if (!empty($gtinValue)) {
-                $entry->addChild('g:gtin', $this->sanitizeData($gtinValue));
-            }
-            $brand = null;
-            if (isset($gtinMap[Gtin::BRAND_ATTRIBUTE])) {
-                $brand = $this->getProductAttributeValue($product, $gtinMap[Gtin::BRAND_ATTRIBUTE]);
-                if (!empty($brand)) {
-                    $entry->addChild('g:brand', $this->sanitizeData($brand));
-                }
-            }
-            $mpn = null;
-            if (isset($gtinMap[Gtin::MPN_ATTRIBUTE])) {
-                $mpn = $this->getProductAttributeValue($product, $gtinMap[Gtin::MPN_ATTRIBUTE]);
-                if (!empty($mpn)) {
-                    $entry->addChild('g:mpn', $this->sanitizeData($mpn));
-                }
-            }
-            if (!empty($brand) && (!empty($gtinValue) || !empty($mpn))) {
-                $identifierExists = 'TRUE';
-            }
-        }
-
-        $entry->addChild('g:identifier_exists', $identifierExists);
-        $entry->addChild('g:link', $this->sanitizeData($productUrl));
-        $entry->addChild('g:title', $this->sanitizeData($productName));
-
-        $categoryName = $this->getCategoryTreeString($product, $storeId);
-        if (!empty($categoryName)) {
-            $cleanCategoryName = $this->sanitizeData($categoryName);
-            $entry->addChild('g:google_product_category', $cleanCategoryName);
-            $entry->addChild('g:product_type', $cleanCategoryName);
-        }
-
-        // Availability is normally determined by status, but can be overridden by custom "turnto_disabled" attribute
-        $turntoDisable = $product->getCustomAttribute('turnto_disabled') ?
-            $product->getCustomAttribute('turnto_disabled')->getValue() :
-            false;
-        $availability = $turntoDisable ? 'out of stock' :
-            (($product->getStatus() == Status::STATUS_ENABLED) ? 'in stock' : 'out of stock');
-
-        $entry->addChild('g:availability', $availability);
-        $productImageUrl = $this->getProductImageUrl($product);
-        $entry->addChild('g:image_link', $this->sanitizeData($productImageUrl));
-        $entry->addChild('g:condition', 'new');
-        $price = $this->priceCurrency->convertAndRound($product->getFinalPrice(), $storeId);
-        $currencyCode = $this->priceCurrency->getCurrency($storeId)->getCurrencyCode();
-        $entry->addChild('g:price', $price . ' ' . $currencyCode);
-        $itemGroupId = $this->getItemGroupId($product, $parent);
-        $entry->addChild('g:item_group_id', $this->sanitizeData($itemGroupId));
-    }
-
-    /**
-     * Gets the deepest tree for given product and returns as "rootNodeName > branchNodeName > leafNodeName"
-     *
-     * @param CatalogProduct $product
-     * @param int|StoreInterface|string $storeId
-     * @return string
-     * @throws LocalizedException
-     */
-    protected function getCategoryTreeString(CatalogProduct $product, $storeId)
-    {
-        $categoryName = '';
-        $categories = $product->getCategoryCollection()->setStoreId($storeId)->addAttributeToSelect('name');
-        $deepestLength = 0;
-        $deepestTree = [];
-
-        foreach ($categories as $category) {
-            $tempTree = $this->getCategoryBranch($category);
-            $treeLength = count($tempTree);
-            if ($treeLength > $deepestLength) {
-                $deepestLength = $treeLength;
-                $deepestTree = $tempTree;
-            }
-        }
-
-        foreach (array_reverse($deepestTree) as $node) {
-            $nodeName = $node->getName();
-            if (!empty($nodeName)) {
-                if (!empty($categoryName)) {
-                    $categoryName .= ' > ';
-                }
-                $categoryName .= $node->getName();
-            }
-        }
-
-        return $categoryName;
-    }
-
-    /**
-     * Recursively walks category chain from leaf to root while writing the traversed branch to an array
-     *
-     * @param Category $category
-     * @param array                           $categoryBranch
-     *
-     * @return array
-     */
-    protected function getCategoryBranch(Category $category, array $categoryBranch = [])
-    {
-        try {
-            $parent = $category->getParentCategory();
-        } catch (NoSuchEntityException $isRootEntity) {
-            $parent = null;
-        } finally {
-            $categoryBranch[] = $category;
-            if (isset($parent)) {
-                return $this->getCategoryBranch($parent, $categoryBranch);
-            } else {
-                return $categoryBranch;
-            }
-        }
+        $this->feedGeneratorFactory = $feedGeneratorFactory;
+        $this->resourceConnection = $resourceConnection;
+        $this->exportProduct = $exportProduct;
+        $this->categoryPathResolver = $categoryPathResolver;
     }
 
     /**
@@ -528,52 +136,238 @@ class Catalog
                 $this->config->getIsEnabled($storeId) &&
                 $this->config->getConfigValue(Config::PRODUCT_ENABLE_AUTOMATIC_SUBMISSION, $storeId)
             ) {
+                $emulationStarted = false;
+                $page = 1;
+                $productCount = 0;
+                $fileIndex = 1;
+                $generator = null;
                 try {
-                    $page = 1;
+                    $feedFormat = $this->config->getFeedFormat($storeId);
+                    $siteKey = $this->config->getSiteKey($storeId);
+                    $authorizationKey = $this->config->getAuthorizationKey($storeId);
+                    $submissionUrl = $this->config->getConfigValue(Config::PRODUCT_FEED_SUBMISSION_URL, $storeId);
+
+                    if (!in_array($feedFormat, [FeedFormat::GOOGLE_PRODUCT, FeedFormat::COMMERCE], true)) {
+                        $this->logger->error(
+                            'TurnTo catalog export skipped due to unsupported feed format',
+                            [
+                                'store_id' => $storeId,
+                                'feed_format' => $feedFormat
+                            ]
+                        );
+                        continue;
+                    }
+
+                    if (empty($siteKey) || empty($authorizationKey) || empty($submissionUrl)) {
+                        $this->logger->error(
+                            'TurnTo catalog export skipped due to incomplete TurnTo credentials',
+                            [
+                                'store_id' => $storeId,
+                                'site_key_set' => !empty($siteKey),
+                                'auth_key_set' => !empty($authorizationKey),
+                                'submission_url_set' => !empty($submissionUrl)
+                            ]
+                        );
+                        continue;
+                    }
+
                     $this->emulation->startEnvironmentEmulation($storeId, Area::AREA_FRONTEND, true);
-                    while ($feed = $this->generateProductFeed($store, $page)) {
+                    $emulationStarted = true;
+                    $generator = $this->feedGeneratorFactory->create($feedFormat);
+                    $feedStyle = $generator->getFeedStyle();
+
+                    $batchSize = 10000;
+                    $pageSize = 500;
+                    $pagesPerBatch = ceil($batchSize / $pageSize);
+                    $products = $this->getProducts($storeId, $page, $pageSize);
+                    if (!$products) {
+                        continue;
+                    }
+                    $totalPages = $this->totalPages;
+                    $totalFiles = $totalPages > 0 ? ceil($totalPages / $pagesPerBatch) : 0;
+
+                    while (true) {
                         try {
-                            $fileName = sprintf('%s_of_%s_store_%s_%s', $page, $this->totalPages, $storeId, self::FEED_STYLE);
-                            $this->feedClient->transmitFeedFile($feed, $fileName, self::FEED_STYLE, $store->getCode());
+                            $productIds = [];
+                            foreach ($products as $product) {
+                                $productIds[] = $product->getId();
+                            }
+
+                            $childProducts = [];
+                            if ($this->config->getUseChildSku($storeId)) {
+                                $simpleIds = [];
+                                foreach ($products as $product) {
+                                    if ($product->getTypeId() !== Configurable::TYPE_CODE) {
+                                        $simpleIds[] = $product->getId();
+                                    }
+                                }
+
+                                if (!empty($simpleIds)) {
+                                    $connection = $this->resourceConnection->getConnection();
+                                    $select = $connection->select()
+                                        ->from(['l' => $connection->getTableName('catalog_product_super_link')], ['parent_id', 'product_id'])
+                                        ->join(['pe' => $connection->getTableName('catalog_product_entity')], 'pe.entity_id = l.parent_id', ['parent_sku' => 'sku'])
+                                        ->where('l.product_id IN (?)', $simpleIds);
+                                    $rows = $connection->fetchAll($select);
+
+                                    if (!empty($rows)) {
+                                        $parentMap = [];
+                                        $emptyCollection = $this->productCollectionFactory->create();
+                                        $parentIds = array_values(array_unique(array_map('intval', array_column($rows, 'parent_id'))));
+                                        $parentCollection = $this->productCollectionFactory->create();
+                                        $parentCollection->setStoreId($storeId)
+                                            ->addAttributeToSelect(['url_key', 'url_path'])
+                                            ->addFieldToFilter('entity_id', ['in' => $parentIds]);
+                                        $loadedParentProducts = [];
+                                        foreach ($parentCollection as $parentProduct) {
+                                            $loadedParentProducts[(int) $parentProduct->getId()] = $parentProduct;
+                                        }
+
+                                        foreach ($rows as $row) {
+                                            $parentId = (int) $row['parent_id'];
+
+                                            if (!isset($parentMap[$parentId])) {
+                                                if (isset($loadedParentProducts[$parentId])) {
+                                                    $parentProduct = $loadedParentProducts[$parentId];
+                                                } else {
+                                                    $parentProduct = $emptyCollection->getNewEmptyItem();
+                                                    $parentProduct->setData([
+                                                        'entity_id' => $parentId,
+                                                        'sku' => $row['parent_sku'],
+                                                        'type_id' => 'configurable',
+                                                        'store_id' => $storeId
+                                                    ]);
+                                                }
+
+                                                $parentMap[$parentId] = $parentProduct;
+                                            }
+
+                                            $childProducts[(int) $row['product_id']] = $parentMap[$parentId];
+                                        }
+
+                                        $productIds = array_merge($productIds, $parentIds);
+
+                                        unset($emptyCollection, $parentMap);
+                                    }
+                                }
+                            }
+
+                            $categoryProductIds = $productIds;
+                            $this->exportProduct->preloadRewriteUrls($storeId, $productIds);
+                            $this->categoryPathResolver->preloadCategoryPaths($storeId, $categoryProductIds);
+
+                            if (!$generator->isFeedOpen()) {
+                                $generator->beginFeed($store);
+                            }
+
+                            foreach ($products as $product) {
+                                $parent = isset($childProducts[(int) $product->getId()]) ? $childProducts[(int) $product->getId()] : false;
+                                if ($generator->addProduct($product, $parent, $storeId)) {
+                                    $productCount++;
+                                }
+                            }
+
+                            $products->clear();
+                            unset($products);
+
+                            if ($productCount >= $batchSize) {
+                                $feedData = $generator->finishFeed();
+                                $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);
+
+                                try {
+                                    $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
+                                } catch (Exception $e) {
+                                    $this->logger->error(
+                                        'TurnTo catalog export transmit file error',
+                                        [
+                                            'store_id' => $storeId,
+                                            'file_name' => $fileName,
+                                            'page' => $page,
+                                            'batch_size' => $batchSize,
+                                            'file_index' => $fileIndex,
+                                            'exception' => $e
+                                        ]
+                                    );
+                                    throw $e;
+                                }
+
+                                $productCount = 0;
+                                $fileIndex++;
+                            }
                         } catch (Exception $e) {
                             $this->logger->error(
-                                "TurnTo catalog export error sending page $page.",
+                                'TurnTo catalog export error sending page',
                                 [
+                                    'store_id' => $storeId,
+                                    'store_code' => $store->getCode(),
+                                    'page' => $page ?? null,
                                     'exception' => $e
                                 ]
                             );
+                            throw $e;
                         }
+
+                        if ($page >= $totalPages) {
+                            break;
+                        }
+
                         $page++;
+                        $products = $this->getProducts($storeId, $page, $pageSize, false);
+                        if (!$products) {
+                            break;
+                        }
+                    }
+
+                    if ($generator->isFeedOpen() && $productCount > 0) {
+                        $feedData = $generator->finishFeed();
+                        $totalFiles = ceil($this->totalPages / $pagesPerBatch);
+                        $fileName = sprintf('%s_of_%s_store_%s_%s', $fileIndex, $totalFiles, $storeId, $feedStyle);
+                        try {
+                            $this->feedClient->transmitFeedFile($feedData, $fileName, $feedStyle, $store->getCode());
+                        } catch (Exception $e) {
+                            $this->logger->error(
+                                'TurnTo catalog export transmit file error',
+                                [
+                                    'store_id' => $storeId,
+                                    'file_name' => $fileName,
+                                    'exception' => $e
+                                ]
+                            );
+                            throw $e;
+                        }
+                    } elseif ($generator->isFeedOpen()) {
+                        $generator->finishFeed();
                     }
                 } catch (Exception $e) {
+                    if ($generator !== null && $generator->isFeedOpen()) {
+                        try {
+                            $generator->finishFeed();
+                        } catch (Exception $finishException) {
+                            $this->logger->error(
+                                'TurnTo catalog export failed to finish feed',
+                                [
+                                    'store_id' => $storeId,
+                                    'store_code' => $store->getCode(),
+                                    'exception' => $finishException
+                                ]
+                            );
+                        }
+                    }
+
                     $this->logger->error(
                         'Catalog export error',
                         [
                             'exception' => $e,
-                            'storeId' => $storeId,
+                            'store_id' => $storeId,
+                            'store_code' => $store->getCode(),
                         ]
                     );
                 } finally {
-                    $this->emulation->stopEnvironmentEmulation();
+                    if ($emulationStarted) {
+                        $this->emulation->stopEnvironmentEmulation();
+                    }
                 }
             }
-        }
-    }
-
-    /**
-     * Get item group ID for a given product
-     *
-     * @param CatalogProduct $product
-     * @param CatalogProduct|bool $parent
-     *
-     * @return string
-     */
-    public function getItemGroupId($product, $parent)
-    {
-        if ($parent) {
-            return $parent->getSku();
-        } else {
-            return $product->getSku();
         }
     }
 
@@ -584,25 +378,35 @@ class Catalog
      * @param int|string $storeId
      * @param int $page
      * @param ?int $pageCount
+     * @param bool $fetchTotalPages
      * @return Collection|false
+     * @throws LocalizedException
      */
-    public function getProducts($storeId, $page, $pageCount = 10000)
+    public function getProducts($storeId, $page, $pageCount = 500, $fetchTotalPages = true)
     {
         $collection = $this->productCollectionFactory->create()
             ->setStoreId($storeId)
-            ->addAttributeToSelect('id')
+            ->addAttributeToSelect('url_key')
             ->addAttributeToSelect('name')
             ->addAttributeToSelect('sku')
-            ->addAttributeToSelect('url_path')
-            ->addAttributeToSelect('url_key')
-            ->addAttributeToSelect('url_in_store')
             ->addAttributeToSelect('image')
-            ->addAttributeToSelect('quantity_and_stock_status')
             ->addAttributeToSelect('price')
             ->addAttributeToSelect('status')
             ->addAttributeToSelect('turnto_disabled')
             ->addUrlRewrite()
+            ->setOrder('entity_id', 'ASC')
             ->setPage($page, $pageCount);
+
+        $collection->joinTable(
+            ['stock_item' => 'cataloginventory_stock_item'],
+            'product_id=entity_id',
+            [
+                'qty' => 'qty',
+                'is_in_stock' => 'is_in_stock'
+            ],
+            '{{table}}.stock_id=1',
+            'left'
+        );
 
         $gtinMap = $this->gtinConfig->getGtinAttributesMap($storeId);
 
@@ -626,12 +430,17 @@ class Catalog
 
         $collection->addStoreFilter($storeId);
 
-        //used to generate file name 1_of_$totalPages.xml
-        $this->totalPages = $collection->getLastPageNumber();
-
-        //stop the feed once we get to the last page
-        if ($this->totalPages < $page) {
+        if (!$fetchTotalPages && $this->totalPages > 0 && $page > $this->totalPages) {
             return false;
+        }
+
+        if ($fetchTotalPages) {
+            //used to generate file name 1_of_$totalPages.xml
+            $this->totalPages = $collection->getLastPageNumber();
+            //stop the feed once we get to the last page
+            if ($this->totalPages < $page) {
+                return false;
+            }
         }
 
         return $collection;

--- a/Model/Export/Catalog.php
+++ b/Model/Export/Catalog.php
@@ -134,7 +134,7 @@ class Catalog
             $storeId = $store->getId();
             if (
                 $this->config->getIsEnabled($storeId) &&
-                $this->config->getConfigValue(Config::PRODUCT_ENABLE_AUTOMATIC_SUBMISSION, $storeId)
+                $this->config->getConfigBool(Config::PRODUCT_ENABLE_AUTOMATIC_SUBMISSION, $storeId)
             ) {
                 $emulationStarted = false;
                 $page = 1;

--- a/Model/Export/CategoryPathResolver.php
+++ b/Model/Export/CategoryPathResolver.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Model\Export;
+
+use Exception;
+use Magento\Framework\App\ResourceConnection;
+use TurnTo\SocialCommerce\Logger\Monolog;
+
+/**
+ * Resolves category paths for products in a page-sized batch.
+ */
+class CategoryPathResolver
+{
+    /**
+     * @var int|null
+     */
+    protected $cachedStoreId;
+
+    /**
+     * @var ResourceConnection
+     */
+    protected $resourceConnection;
+
+    /**
+     * @var Monolog
+     */
+    protected $logger;
+
+    /**
+     * @var array<int, array<int, array{id:string,name:string}>>
+     */
+    protected $categoryPathByProductId = [];
+
+    /**
+     * @var int|null
+     */
+    protected $nameAttributeId;
+
+    /**
+     * @var int|null
+     */
+    protected $categoryEntityTypeId;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param Monolog $logger
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        Monolog $logger
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Cache the deepest category path for each product for one store/page cycle.
+     *
+     * @param int|string $storeId
+     * @param int[] $productIds
+     * @return void
+     */
+    public function preloadCategoryPaths($storeId, array $productIds): void
+    {
+        $storeId = (int) $storeId;
+        $this->cachedStoreId = $storeId;
+        $this->categoryPathByProductId = [];
+
+        $productIds = array_values(array_filter(array_unique(array_map('intval', $productIds)), function ($id) {
+            return $id > 0;
+        }));
+
+        foreach ($productIds as $productId) {
+            $this->categoryPathByProductId[$productId] = [];
+        }
+
+        if (empty($productIds)) {
+            return;
+        }
+
+        try {
+            $connection = $this->resourceConnection->getConnection();
+
+            $categoryProductRows = $connection->fetchAll(
+                $connection->select()
+                    ->from(
+                        $connection->getTableName('catalog_category_product'),
+                        ['product_id', 'category_id']
+                    )
+                    ->where('product_id IN (?)', $productIds)
+                    ->order('category_id ASC')
+            );
+
+            if (empty($categoryProductRows)) {
+                return;
+            }
+
+            $categoriesByProduct = [];
+            $categoryIds = [];
+            foreach ($categoryProductRows as $row) {
+                $productId = (int) $row['product_id'];
+                $categoryId = (int) $row['category_id'];
+                if ($productId <= 0 || $categoryId <= 0) {
+                    continue;
+                }
+
+                $categoriesByProduct[$productId][] = $categoryId;
+                $categoryIds[] = $categoryId;
+            }
+
+            if (empty($categoryIds)) {
+                return;
+            }
+
+            $categoryIds = array_values(array_unique($categoryIds));
+            $entityTypeId = $this->getCatalogCategoryEntityTypeId($connection);
+            if ($entityTypeId === null) {
+                return;
+            }
+            $nameAttributeId = $this->getCatalogCategoryNameAttributeId($connection, $entityTypeId);
+            if ($nameAttributeId === null) {
+                return;
+            }
+
+            $pathRows = $connection->fetchAll(
+                $connection->select()
+                    ->from(
+                        $connection->getTableName('catalog_category_entity'),
+                        ['entity_id', 'path']
+                    )
+                    ->where('entity_id IN (?)', $categoryIds)
+            );
+            $pathByCategory = [];
+            $requiredCategoryIds = [];
+            foreach ($pathRows as $row) {
+                $entityId = (int) $row['entity_id'];
+                $path = (string) $row['path'];
+                $pathIds = [];
+                if ($path !== '') {
+                    foreach (explode('/', $path) as $pathCategoryId) {
+                        $categoryId = (int) $pathCategoryId;
+                        if ($categoryId > 0) {
+                            $pathIds[] = $categoryId;
+                            $requiredCategoryIds[$categoryId] = true;
+                        }
+                    }
+                }
+                if (empty($pathIds)) {
+                    $pathIds = [$entityId];
+                    $requiredCategoryIds[$entityId] = true;
+                }
+
+                $pathByCategory[$entityId] = $pathIds;
+            }
+            foreach ($categoryIds as $categoryId) {
+                $requiredCategoryIds[$categoryId] = true;
+            }
+            $allCategoryIds = array_map('intval', array_keys($requiredCategoryIds));
+            if (empty($allCategoryIds)) {
+                return;
+            }
+
+            $nameRows = $connection->fetchAll(
+                $connection->select()
+                    ->from(
+                        $connection->getTableName('catalog_category_entity_varchar'),
+                        ['entity_id', 'store_id', 'value']
+                    )
+                    ->where('attribute_id = ?', $nameAttributeId)
+                    ->where('entity_id IN (?)', $allCategoryIds)
+                    ->where('store_id IN (?)', [0, $storeId])
+            );
+            $nameByCategory = [];
+            foreach ($nameRows as $row) {
+                $categoryId = (int) $row['entity_id'];
+                $categoryStoreId = (int) $row['store_id'];
+                $categoryName = $row['value'];
+                if ($categoryName === null || $categoryName === '') {
+                    continue;
+                }
+
+                if ($categoryStoreId === $storeId || !isset($nameByCategory[$categoryId])) {
+                    $nameByCategory[$categoryId] = (string) $categoryName;
+                }
+            }
+
+            foreach ($categoriesByProduct as $productId => $categoriesForProduct) {
+                $bestDepth = -1;
+                $bestPath = [];
+
+                foreach ($categoriesForProduct as $categoryId) {
+                    $pathCategoryIds = $pathByCategory[$categoryId] ?? [$categoryId];
+                    $pathDepth = count($pathCategoryIds);
+                    if ($pathDepth <= $bestDepth) {
+                        continue;
+                    }
+                    $bestDepth = $pathDepth;
+                    $bestPath = $pathCategoryIds;
+                }
+
+                $categoryPath = [];
+                foreach ($bestPath as $pathCategoryId) {
+                    if (isset($nameByCategory[$pathCategoryId])) {
+                        $categoryPath[] = [
+                            'id' => (string) $pathCategoryId,
+                            'name' => (string) $nameByCategory[$pathCategoryId]
+                        ];
+                    }
+                }
+                $this->categoryPathByProductId[$productId] = $categoryPath;
+            }
+        } catch (Exception $e) {
+            $this->logger->error(
+                'Could not preload category paths for product feed',
+                [
+                    'exception' => $e,
+                    'store_id' => $storeId,
+                    'product_count' => count($productIds)
+                ]
+            );
+        }
+    }
+
+    /**
+     * @param int $storeId
+     * @param int $productId
+     * @return array{id:string,name:string}|null
+     */
+    public function getCategoryPath(int $storeId, int $productId): ?array
+    {
+        if ($this->cachedStoreId !== $storeId) {
+            return null;
+        }
+        if (!array_key_exists($productId, $this->categoryPathByProductId)) {
+            return null;
+        }
+
+        return $this->categoryPathByProductId[$productId];
+    }
+
+    /**
+     * @param \Magento\Framework\DB\Adapter\AdapterInterface $connection
+     * @return int|null
+     */
+    protected function getCatalogCategoryEntityTypeId($connection)
+    {
+        if ($this->categoryEntityTypeId !== null) {
+            return $this->categoryEntityTypeId;
+        }
+
+        $entityType = $connection->fetchOne(
+            $connection->select()
+                ->from(
+                    $connection->getTableName('eav_entity_type'),
+                    ['entity_type_id']
+                )
+                ->where('entity_type_code = ?', 'catalog_category')
+        );
+        if (empty($entityType)) {
+            return null;
+        }
+        $this->categoryEntityTypeId = (int) $entityType;
+        return $this->categoryEntityTypeId;
+    }
+
+    /**
+     * @param \Magento\Framework\DB\Adapter\AdapterInterface $connection
+     * @param int $entityTypeId
+     * @return int|null
+     */
+    protected function getCatalogCategoryNameAttributeId($connection, int $entityTypeId)
+    {
+        if ($this->nameAttributeId !== null) {
+            return $this->nameAttributeId;
+        }
+
+        $attributeId = $connection->fetchOne(
+            $connection->select()
+                ->from(
+                    $connection->getTableName('eav_attribute'),
+                    ['attribute_id']
+                )
+                ->where('attribute_code = ?', 'name')
+                ->where('entity_type_id = ?', $entityTypeId)
+        );
+        if (empty($attributeId)) {
+            return null;
+        }
+        $this->nameAttributeId = (int) $attributeId;
+        return $this->nameAttributeId;
+    }
+}

--- a/Model/Export/Orders.php
+++ b/Model/Export/Orders.php
@@ -16,12 +16,14 @@ use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ProductRepository;
 use Magento\Framework\Api\AbstractSimpleObject;
 use Magento\Framework\Api\Filter;
-use Magento\Framework\Api\FilterBuilder;
+use Magento\Framework\Api\FilterBuilderFactory;
 use Magento\Framework\Api\SearchCriteria;
-use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SearchCriteriaBuilderFactory;
 use Magento\Framework\Api\SortOrder;
-use Magento\Framework\Api\SortOrderBuilder;
+use Magento\Framework\Api\SortOrderBuilderFactory;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Filesystem\Io\File;
 use Magento\Framework\Intl\DateTimeFactory;
@@ -43,7 +45,7 @@ class Orders
     /**#@+
      * Field Id keys
      */
-    CONST MAIN_TABLE_PREFIX = 'main_table.';
+    const MAIN_TABLE_PREFIX = 'main_table.';
 
     const UPDATED_AT_FIELD_ID = 'updated_at';
 
@@ -65,6 +67,8 @@ class Orders
 
     const FEED_STYLE = 'tab-style.1';
     /**#@-*/
+
+    protected const LOOKBACK_INTERVAL = 'P2D';
 
     /**
      * Default page size
@@ -134,17 +138,17 @@ class Orders
      */
     protected $feedClient;
     /**
-     * @var SearchCriteriaBuilder
+     * @var SearchCriteriaBuilderFactory
      */
-    protected $searchCriteriaBuilder;
+    protected $searchCriteriaBuilderFactory;
     /**
-     * @var SortOrderBuilder
+     * @var SortOrderBuilderFactory
      */
-    protected $sortOrderBuilder;
+    protected $sortOrderBuilderFactory;
     /**
-     * @var FilterBuilder
+     * @var FilterBuilderFactory
      */
-    protected $filterBuilder;
+    protected $filterBuilderFactory;
 
     /**
      * Orders constructor.
@@ -163,9 +167,9 @@ class Orders
      * @param File $fileSystem
      * @param OrderCollectionFactory $orderCollection
      * @param ExportProduct $exportProduct
-     * @param FilterBuilder $filterBuilder
-     * @param SearchCriteriaBuilder $searchCriteriaBuilder
-     * @param SortOrderBuilder $sortOrderBuilder
+     * @param FilterBuilderFactory $filterBuilderFactory
+     * @param SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory
+     * @param SortOrderBuilderFactory $sortOrderBuilderFactory
      */
     public function __construct(
         Config $config,
@@ -182,9 +186,9 @@ class Orders
         File $fileSystem,
         OrderCollectionFactory $orderCollection,
         ExportProduct $exportProduct,
-        FilterBuilder $filterBuilder,
-        SearchCriteriaBuilder $searchCriteriaBuilder,
-        SortOrderBuilder $sortOrderBuilder
+        FilterBuilderFactory $filterBuilderFactory,
+        SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory,
+        SortOrderBuilderFactory $sortOrderBuilderFactory
     ) {
         $this->config = $config;
         $this->logger = $logger;
@@ -200,9 +204,9 @@ class Orders
         $this->fileSystem = $fileSystem;
         $this->orderCollectionFactory = $orderCollection;
         $this->exportProduct = $exportProduct;
-        $this->filterBuilder = $filterBuilder;
-        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
-        $this->sortOrderBuilder = $sortOrderBuilder;
+        $this->filterBuilderFactory = $filterBuilderFactory;
+        $this->searchCriteriaBuilderFactory = $searchCriteriaBuilderFactory;
+        $this->sortOrderBuilderFactory = $sortOrderBuilderFactory;
     }
 
     /**
@@ -213,16 +217,16 @@ class Orders
     {
         foreach ($this->storeManager->getStores() as $store) {
             if ($this->config->getIsEnabled($store->getCode())
-                && $this->config->getConfigValue(Config::ORDER_ENABLE_FEED, $store->getCode())
+                && $this->config->getConfigBool(Config::ORDER_ENABLE_FEED, $store->getCode())
             ) {
                 try {
-                    $orderFeed =$this->getOrdersFeed(
+                    $orderFeed = $this->getOrdersFeed(
                         $store->getId(),
-                        $this->dateTimeFactory->create('now', new DateTimeZone('UTC'))->sub(new DateInterval('P25D')),
+                        $this->dateTimeFactory->create('now', new DateTimeZone('UTC'))
+                            ->sub(new DateInterval(static::LOOKBACK_INTERVAL)),
                         $this->dateTimeFactory->create(
                             'now',
                             new DateTimeZone('UTC')
-
                         )
                     );
                     $this->feedClient->transmitFeedFile($orderFeed, self::FEED_NAME, self::FEED_STYLE, $store->getCode());
@@ -244,8 +248,9 @@ class Orders
      * @param DateTime $fromDate
      * @param DateTime $toDate
      * @param bool $forceIncludeAllItems
-     *
-     * @return null|string
+     * @return string
+     * @throws FileSystemException
+     * @throws LocalizedException
      */
     public function getOrdersFeed(
         $storeId,
@@ -253,12 +258,15 @@ class Orders
         DateTime $toDate,
         bool $forceIncludeAllItems = false
     ) {
-        $csvData = null;
+        $outputHandle = null;
         try {
 	        $this->fileSystem->checkAndCreateFolder($this->directoryList->getPath(DirectoryList::TMP));
 
-            $outputFile = $this->directoryList->getPath(DirectoryList::TMP) . '/tuntoexport.csv';
+            $outputFile = $this->directoryList->getPath(DirectoryList::TMP) . '/turntoexport.csv';
             $outputHandle = fopen($outputFile, 'w+');
+            if ($outputHandle === false) {
+                throw new LocalizedException(__('Unable to open temporary file.'));
+            }
             fputcsv(
                 $outputHandle,
                 [
@@ -278,24 +286,17 @@ class Orders
                 ],
                 "\t",
                 '"',
-                "\\",
-                PHP_EOL
+                "\\"
             );
             $orderFeed = $this->getOrders($storeId, $fromDate, $toDate);
             $this->writeOrdersFeed($orderFeed, $outputHandle, $forceIncludeAllItems);
             rewind($outputHandle);
             $csvData = stream_get_contents($outputHandle);
-
-        } catch (Exception $e) {
-            $this->logger->error(
-                'An error occurred while creating or writing data to the Historical Orders Feed export file. Error:',
-                [
-                    'storeId' => $storeId,
-                    'exception' => $e
-                ]
-            );
+            if ($csvData === false || $csvData === '') {
+                throw new LocalizedException(__('Invalid CSV data'));
+            }
         } finally {
-            if (isset($outputHandle)) {
+            if (is_resource($outputHandle)) {
                 fclose($outputHandle);
             }
         }
@@ -423,7 +424,7 @@ class Orders
         $items = $this->addShipDateToItemData($items, $orderId, $order->getStoreId());
         if (
             !$forceIncludeAllItems
-            && $this->config->getConfigValue(Config::ORDER_EXCLUDE_ITEMS_WITHOUT_DELIVERY_DATE, $order->getStore()->getCode())
+            && $this->config->getConfigBool(Config::ORDER_EXCLUDE_ITEMS_WITHOUT_DELIVERY_DATE, $order->getStore()->getCode())
         ) {
             foreach ($items as $key => $item) {
                 if (empty($item['shipDate'])) {
@@ -450,7 +451,7 @@ class Orders
         $pageSize = $shipmentsList->getPageSize();
 
         // If this setting is on, we only send shipment data if the whole order has shipped
-        $configExcludeDeliveryDateUntilAllItemsShipped = $this->config->getConfigValue(Config::ORDER_EXCLUDE_DELIVERY_DATE_ON_PARTIAL_SHIPMENT, $storeId);
+        $configExcludeDeliveryDateUntilAllItemsShipped = $this->config->getConfigBool(Config::ORDER_EXCLUDE_DELIVERY_DATE_ON_PARTIAL_SHIPMENT, $storeId);
         $allItemsShipped = false;
         if ($configExcludeDeliveryDateUntilAllItemsShipped) {
             $allItemsShipped = $this->getAllOrdersShipped($orderId);
@@ -505,7 +506,7 @@ class Orders
      */
     public function getFilter($fieldId, $value, $conditionType)
     {
-        return $this->filterBuilder
+        return $this->filterBuilderFactory->create()
             ->setField($fieldId)
             ->setValue($value)
             ->setConditionType($conditionType)
@@ -520,11 +521,13 @@ class Orders
      */
     public function getSearchCriteria($sortOrder, $filters = [], $pageSize = self::DEFAULT_PAGE_SIZE)
     {
-        $searchCriteriaBuilder = $this->searchCriteriaBuilder->setPageSize($pageSize)->addSortOrder($sortOrder);
+        $searchCriteriaBuilder = $this->searchCriteriaBuilderFactory->create();
+        $searchCriteriaBuilder->setPageSize($pageSize)->addSortOrder($sortOrder);
         foreach ($filters as $filter) {
             //add as separate groups to get AND join instead of OR
-            $searchCriteriaBuilder = $searchCriteriaBuilder->addFilters([$filter]);
+            $searchCriteriaBuilder->addFilters([$filter]);
         }
+
         return $searchCriteriaBuilder->create();
     }
 
@@ -535,7 +538,8 @@ class Orders
      */
     public function getSortOrder($fieldId, $direction = SortOrder::SORT_ASC)
     {
-        return $this->sortOrderBuilder->setField($fieldId)->setDirection($direction)->create();
+        return $this->sortOrderBuilderFactory->create()
+            ->setField($fieldId)->setDirection($direction)->create();
     }
 
     /**
@@ -578,7 +582,7 @@ class Orders
         $row[] = $this->productHelper->getImageUrl($product);
         $row[] = $shipmentDate;
 
-        fputcsv($outputHandle, $row, "\t");
+        fputcsv($outputHandle, $row, "\t", '"', "\\");
     }
 
     /**
@@ -620,13 +624,13 @@ class Orders
         $orderList->addFieldToFilter(self::MAIN_TABLE_PREFIX . self::STORE_ID_FIELD_ID, ['eq' => $storeId]);
         $orderList->addFieldToFilter(
             [self::MAIN_TABLE_PREFIX . self::UPDATED_AT_FIELD_ID, 'shipment_track.updated_at'], [
-                ['gteq' => $fromDate->format(DATE_ATOM)],
-                ['gteq' => $fromDate->format(DATE_ATOM)]
+                ['gteq' => $fromDate->format('Y-m-d H:i:s')],
+                ['gteq' => $fromDate->format('Y-m-d H:i:s')]
             ]
         );
         $orderList->addFieldToFilter(
             self::MAIN_TABLE_PREFIX . self::UPDATED_AT_FIELD_ID,
-            ['lteq' => $toDate->format(DATE_ATOM)]
+            ['lteq' => $toDate->format('Y-m-d H:i:s')]
         );
         $orderList->getSelect()->group('main_table.entity_id');
 

--- a/Model/Export/Product.php
+++ b/Model/Export/Product.php
@@ -10,23 +10,25 @@ namespace TurnTo\SocialCommerce\Model\Export;
 use Exception;
 use Magento\Catalog\Model\Product as CatalogProduct;
 use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\UrlRewrite\Model\UrlFinderInterface;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 use TurnTo\SocialCommerce\Logger\Monolog;
 
+/**
+ * Export Product
+ */
 class Product
 {
     /**
-     * @var array
+     * @var array<int, string>|null
      */
     protected $rewriteUrls;
 
     /**
-     * @var
+     * @var int|null
      */
-    protected $storeId;
+    protected $cachedStoreId;
 
     /**
      * @var UrlFinderInterface
@@ -42,6 +44,11 @@ class Product
      */
     protected $logger;
 
+    /**
+     * @param UrlFinderInterface $urlFinder
+     * @param StoreManagerInterface $storeManager
+     * @param Monolog $logger
+     */
     public function __construct(
         UrlFinderInterface $urlFinder,
         StoreManagerInterface $storeManager,
@@ -54,55 +61,161 @@ class Product
 
     /**
      * Required to get beautified urls in cron (see https://github.com/magento/magento2/issues/3074)
+     *
      * @param CatalogProduct $product
-     * @param $storeId
+     * @param int|string $storeId
      * @return string
      */
     public function getProductUrl(CatalogProduct $product, $storeId)
     {
-        if (!$this->rewriteUrls){
-            $this->getRewriteUrls($storeId);
+        $storeId = (int) $storeId;
+
+        if ($this->cachedStoreId !== $storeId) {
+            $this->cachedStoreId = $storeId;
+            $this->rewriteUrls = null;
         }
 
-        if (isset($this->rewriteUrls[$product->getId()])) {
-            return $this->rewriteUrls[$product->getId()];
+        if ($this->rewriteUrls !== null) {
+            $productId = $product->getId();
+            if (isset($this->rewriteUrls[$productId])) {
+                return $this->rewriteUrls[$productId];
+            }
         }
 
-        return $product->getProductUrl();
+        return $this->resolveProductUrlWithoutPreloadedRewrites($product, $storeId);
     }
 
     /**
-     * @param $relativeUrl
-     * @param $storeId
+     * Native URL resolution with explicit store scope (covers order export, CLI, and cache misses).
+     *
+     * @param CatalogProduct $product
+     * @param int $storeId
      * @return string
-     * @throws NoSuchEntityException
      */
-    protected function getAbsoluteUrl($relativeUrl, $storeId)
+    protected function resolveProductUrlWithoutPreloadedRewrites(CatalogProduct $product, int $storeId)
     {
-        $storeUrl = $this->storeManager->getStore($storeId)->getBaseUrl();
+        $originalStoreId = $product->getStoreId();
+        try {
+            $product->setStoreId($storeId);
+            return $product->getProductUrl();
+        } finally {
+            $product->setStoreId($originalStoreId);
+        }
+    }
+
+    /**
+     * Build an absolute URL from a store-relative request path.
+     *
+     * @param string $relativeUrl
+     * @param string $storeUrl
+     * @return string
+     */
+    protected function getAbsoluteUrl($relativeUrl, $storeUrl)
+    {
         return rtrim($storeUrl, '/') . '/' . ltrim($relativeUrl, '/');
     }
 
     /**
-     * @param $storeId
+     * Batch-load product rewrites for the given store to avoid repeated lookups during catalog feed generation.
+     *
+     * When several rewrites exist per product (category paths), the canonical product rewrite is preferred.
+     *
+     * @param int|string $storeId
+     * @param int[] $productIds
      * @return void
      */
-    protected function getRewriteUrls($storeId)
+    public function preloadRewriteUrls($storeId, array $productIds)
     {
+        $storeId = (int) $storeId;
+        $this->cachedStoreId = $storeId;
         $this->rewriteUrls = [];
-        $urlRewrites = $this->urlFinder->findAllByData(
-            [
-                UrlRewrite::ENTITY_TYPE =>
-                    ProductUrlRewriteGenerator::ENTITY_TYPE,
-                UrlRewrite::STORE_ID => $storeId
-            ]
-        );
+
+        if ($productIds === []) {
+            return;
+        }
+
+        $productIds = array_values(array_unique(array_map('intval', $productIds)));
+
+        $candidates = [];
+        try {
+            $urlRewrites = $this->urlFinder->findAllByData(
+                [
+                    UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
+                    UrlRewrite::STORE_ID => $storeId,
+                    UrlRewrite::REDIRECT_TYPE => 0,
+                    UrlRewrite::ENTITY_ID => $productIds,
+                ]
+            );
+        } catch (Exception $e) {
+            $this->logger->error($e->getMessage(), ['exception' => $e]);
+            return;
+        }
+
+        try {
+            $storeUrl = $this->storeManager->getStore($storeId)->getBaseUrl();
+        } catch (Exception $e) {
+            $this->logger->error($e->getMessage(), ['exception' => $e]);
+            return;
+        }
+
         foreach ($urlRewrites as $urlRewrite) {
             try {
-                $this->rewriteUrls[$urlRewrite->getEntityId()] = $this->getAbsoluteUrl($urlRewrite->getRequestPath(), $storeId);
+                $entityId = $urlRewrite->getEntityId();
+                $candidates[$entityId][] = [
+                    'url' => $this->getAbsoluteUrl($urlRewrite->getRequestPath(), $storeUrl),
+                    'rewrite' => $urlRewrite,
+                ];
             } catch (Exception $e) {
-                $this->logger->error($e);
+                $this->logger->error($e->getMessage(), ['exception' => $e]);
             }
         }
+
+        foreach ($candidates as $entityId => $rows) {
+            $this->rewriteUrls[$entityId] = $this->pickPreferredProductRewriteUrl($rows);
+        }
+    }
+
+    /**
+     * Prefer canonical product rewrites (no category metadata) over category-scoped paths.
+     *
+     * @param array<int, array{url: string, rewrite: UrlRewrite}> $rows
+     * @return string
+     */
+    protected function pickPreferredProductRewriteUrl(array $rows)
+    {
+        foreach ($rows as $row) {
+            if ($this->isCanonicalProductRewrite($row['rewrite'])) {
+                return $row['url'];
+            }
+        }
+
+        // Fallback: Sort deterministically to ensure consistent exports
+        // Prefer shorter URLs (fewer category segments), then sort alphabetically
+        usort($rows, function ($a, $b) {
+            $pathA = $a['rewrite']->getRequestPath();
+            $pathB = $b['rewrite']->getRequestPath();
+
+            $lengthComparison = strlen($pathA) <=> strlen($pathB);
+            if ($lengthComparison !== 0) {
+                return $lengthComparison;
+            }
+
+            return strcmp($pathA, $pathB);
+        });
+
+        return $rows[0]['url'];
+    }
+
+    /**
+     * Whether the rewrite is the product-level URL (not scoped to a category path).
+     *
+     * @param UrlRewrite $rewrite
+     * @return bool
+     */
+    protected function isCanonicalProductRewrite(UrlRewrite $rewrite)
+    {
+        $metadata = $rewrite->getMetadata() ?? [];
+
+        return empty($metadata['category_id']) && empty($metadata['redirect_type']);
     }
 }

--- a/Model/Import/Ratings.php
+++ b/Model/Import/Ratings.php
@@ -116,6 +116,7 @@ class Ratings
      * @param $sku
      * @param $reviewCount
      * @param $averageRating
+     * @param ProductInterface|null $product
      * @return bool
      * @throws Exception
      */
@@ -123,19 +124,22 @@ class Ratings
         StoreInterface $store,
         $sku,
         $reviewCount,
-        $averageRating
+        $averageRating,
+        $product = null
     ) {
-        $product = $this->productFactory->create()
-            ->setStoreId($store->getId())
-            ->loadByAttribute(
-                ProductInterface::SKU,
-                $sku,
-                [
-                    InstallHelper::RATING_ATTRIBUTE_CODE,
-                    InstallHelper::REVIEW_COUNT_ATTRIBUTE_CODE,
-                    InstallHelper::AVERAGE_RATING_ATTRIBUTE_CODE
-                ]
-            );
+        if (!$product) {
+            $product = $this->productFactory->create()
+                ->setStoreId($store->getId())
+                ->loadByAttribute(
+                    ProductInterface::SKU,
+                    $sku,
+                    [
+                        InstallHelper::RATING_ATTRIBUTE_CODE,
+                        InstallHelper::REVIEW_COUNT_ATTRIBUTE_CODE,
+                        InstallHelper::AVERAGE_RATING_ATTRIBUTE_CODE
+                    ]
+                );
+        }
 
         if (!$product) {
             return false;
@@ -207,15 +211,24 @@ class Ratings
             $feedProducts = [];
             foreach ($this->storeManager->getStores() as $store) {
                 $feedAddress = 'UNK';
-                if (!$this->config->getIsEnabled($store->getCode()) || !$this->config->getConfigValue(Config::AVERAGE_RATING_IMPORT_ENABLED, $store->getCode())) {
+                if (!$this->config->getIsEnabled($store->getCode()) || !$this->config->getConfigBool(Config::AVERAGE_RATING_IMPORT_ENABLED, $store->getCode())) {
                     continue;
                 }
-                // Create an array for reach store
+                // Create an array for each store
                 $feedProducts[$store->getId()] = [];
 
                 try {
                     $feedAddress = $this->getAggregateRatingsFeedAddress($store);
-                    $xmlFeed = simplexml_load_file($feedAddress);
+                    libxml_use_internal_errors(true);
+                    $xmlFeed = @simplexml_load_file($feedAddress);
+                    if (!$xmlFeed) {
+                        throw new UnexpectedValueException('Unable to parse TurnTo aggregate rating feed');
+                    }
+                    if (!isset($xmlFeed->products) || !isset($xmlFeed->products->product)) {
+                        throw new UnexpectedValueException('Aggregate rating feed is missing product data');
+                    }
+
+                    $turnToProductsBySku = [];
                     // Take each product in the feed and update its info
                     foreach ($xmlFeed->products->product as $turnToProduct) {
                         try {
@@ -224,8 +237,6 @@ class Ratings
                             ) {
                                 continue;
                             }
-                            $sku = null;
-                            $reviewCount = null;
 
                             $sku = $this->product->turnToSafeDecoding(
                                 (string)$turnToProduct[self::TURNTO_FEED_KEY_SKU]
@@ -236,24 +247,17 @@ class Ratings
 
                             // Save a record of the product
                             $feedProducts[$store->getId()][$sku] = true;
-
-                            // If the Import Average Rating Aggregate Data setting is on, include related reviews
-                            if ($this->config->getConfigValue(Config::AVERAGE_RATING_IMPORT_AGGREGATE_DATA)) {
-                                $reviewCount = (int)$turnToProduct[self::TURNTO_FEED_KEY_REVIEW_COUNT] +
-                                    $turnToProduct[self::TURNTO_FEED_KEY_RELATED_REVIEW_COUNT];
-                            } else {
-                                $reviewCount = (int)$turnToProduct[self::TURNTO_FEED_KEY_REVIEW_COUNT];
+                            $reviewCount = (int)$turnToProduct[self::TURNTO_FEED_KEY_REVIEW_COUNT];
+                            if ($this->config->getConfigBool(Config::AVERAGE_RATING_IMPORT_AGGREGATE_DATA, $store->getCode())
+                                && isset($turnToProduct[self::TURNTO_FEED_KEY_RELATED_REVIEW_COUNT])
+                            ) {
+                                $reviewCount += (int)$turnToProduct[self::TURNTO_FEED_KEY_RELATED_REVIEW_COUNT];
                             }
 
-                            if ($reviewCount > 0) {
-                                $averageRating = (float)$turnToProduct;
-                                if ($averageRating > 0.0) {
-                                    $this->updateProduct($store, $sku, $reviewCount, $averageRating);
-                                } else {
-                                    throw new UnexpectedValueException('Average rating is a non-positive '
-                                        . 'number despite product having reviews');
-                                }
-                            }
+                            $turnToProductsBySku[$sku] = [
+                                'reviewCount' => $reviewCount,
+                                'averageRating' => (float)$turnToProduct
+                            ];
                         } catch (Exception $e) {
                             $this->logger->error(
                                 'Failed to read TurnTo aggregate rating data for product',
@@ -265,6 +269,43 @@ class Ratings
                             );
                         }
                     }
+
+                    $productsToUpdate = $this->getProductsBySkus(
+                        $store,
+                        array_keys($turnToProductsBySku)
+                    );
+
+                    foreach ($turnToProductsBySku as $productSku => $productData) {
+                        try {
+                            $reviewCount = (int)$productData['reviewCount'];
+                            $averageRating = (float)$productData['averageRating'];
+                            if ($reviewCount <= 0) {
+                                continue;
+                            }
+                            if ($averageRating <= 0.0) {
+                                throw new UnexpectedValueException('Average rating is a non-positive '
+                                    . 'number despite product having reviews');
+                            }
+
+                            $this->updateProduct(
+                                $store,
+                                $productSku,
+                                $reviewCount,
+                                $averageRating,
+                                $productsToUpdate[$productSku] ?? null
+                            );
+                        } catch (Exception $productFeedItemException) {
+                            $this->logger->error(
+                                'Failed to apply aggregate rating data for product',
+                                [
+                                    'exception' => $productFeedItemException,
+                                    'storeCode' => $store->getCode(),
+                                    'sku' => $productSku
+                                ]
+                            );
+                        }
+                    }
+
                     // Now reset all products not in the feed
                     $this->resetProducts($feedProducts, $store);
                 } catch (Exception $feedRetrievalException) {
@@ -276,6 +317,8 @@ class Ratings
                             'feedAddress' => $feedAddress
                         ]
                     );
+                } finally {
+                    libxml_clear_errors();
                 }
             }
         } catch (Exception $exception) {
@@ -286,6 +329,34 @@ class Ratings
                 ]
             );
         }
+    }
+
+    /**
+     * @param StoreInterface $store
+     * @param array $skus
+     *
+     * @return array
+     */
+    protected function getProductsBySkus(StoreInterface $store, array $skus): array
+    {
+        if (empty($skus)) {
+            return [];
+        }
+
+        $collection = $this->productCollectionFactory->create()
+            ->setStoreId($store->getId())
+            ->addAttributeToSelect('sku')
+            ->addAttributeToSelect(InstallHelper::REVIEW_COUNT_ATTRIBUTE_CODE)
+            ->addAttributeToSelect(InstallHelper::RATING_ATTRIBUTE_CODE)
+            ->addAttributeToSelect(InstallHelper::AVERAGE_RATING_ATTRIBUTE_CODE)
+            ->addAttributeToFilter(ProductInterface::SKU, ['in' => array_values(array_unique($skus))]);
+
+        $products = [];
+        foreach ($collection as $product) {
+            $products[$product->getSku()] = $product;
+        }
+
+        return $products;
     }
 
     /**
@@ -308,6 +379,8 @@ class Ratings
             ->addAttributeToSelect('quantity_and_stock_status')
             ->addAttributeToSelect('price')
             ->addAttributeToSelect('status')
+            ->addAttributeToSelect(InstallHelper::AVERAGE_RATING_ATTRIBUTE_CODE)
+            ->addAttributeToSelect(InstallHelper::REVIEW_COUNT_ATTRIBUTE_CODE)
             ->addAttributeToFilter(
                 [
                     [
@@ -329,7 +402,7 @@ class Ratings
         // Loop over products and reset data if not found in $feedProducts
         foreach ($collection as $item) {
             if (!isset($feedProducts[$store->getId()][$item->getSku()])) {
-                $this->updateProduct($store, $item->getSku(), 0, 0);
+                $this->updateProduct($store, $item->getSku(), 0, 0, $item);
             }
         }
     }

--- a/Model/Import/Ratings.php
+++ b/Model/Import/Ratings.php
@@ -219,8 +219,13 @@ class Ratings
 
                 try {
                     $feedAddress = $this->getAggregateRatingsFeedAddress($store);
-                    libxml_use_internal_errors(true);
-                    $xmlFeed = @simplexml_load_file($feedAddress);
+                    $previousLibxmlUseInternalErrors = libxml_use_internal_errors(true);
+                    try {
+                        $xmlFeed = simplexml_load_file($feedAddress);
+                    } finally {
+                        libxml_clear_errors();
+                        libxml_use_internal_errors($previousLibxmlUseInternalErrors);
+                    }
                     if (!$xmlFeed) {
                         throw new UnexpectedValueException('Unable to parse TurnTo aggregate rating feed');
                     }
@@ -317,8 +322,6 @@ class Ratings
                             'feedAddress' => $feedAddress
                         ]
                     );
-                } finally {
-                    libxml_clear_errors();
                 }
             }
         } catch (Exception $exception) {

--- a/Model/Import/Ratings.php
+++ b/Model/Import/Ratings.php
@@ -383,6 +383,7 @@ class Ratings
             ->addAttributeToSelect('price')
             ->addAttributeToSelect('status')
             ->addAttributeToSelect(InstallHelper::AVERAGE_RATING_ATTRIBUTE_CODE)
+            ->addAttributeToSelect(InstallHelper::RATING_ATTRIBUTE_CODE)
             ->addAttributeToSelect(InstallHelper::REVIEW_COUNT_ATTRIBUTE_CODE)
             ->addAttributeToFilter(
                 [

--- a/Plugin/Block/Product/View/Type/ConfigurablePlugin.php
+++ b/Plugin/Block/Product/View/Type/ConfigurablePlugin.php
@@ -7,9 +7,10 @@ declare(strict_types=1);
 
 namespace TurnTo\SocialCommerce\Plugin\Block\Product\View\Type;
 
-use Magento\Catalog\Model\ProductRepository;
+use InvalidArgumentException;
 use Magento\ConfigurableProduct\Block\Product\View\Type\Configurable;
-use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Serialize\Serializer\Json;
+use TurnTo\SocialCommerce\Logger\Monolog;
 use TurnTo\SocialCommerce\Model\Config;
 use TurnTo\SocialCommerce\Model\Product as TurnToProduct;
 
@@ -19,56 +20,101 @@ class ConfigurablePlugin
      * @var Config
      */
     protected $config;
-
-    /**
-     * @var ProductRepository
-     */
-    protected $product;
     /**
      * @var TurnToProduct
      */
     protected $turnToProduct;
+    /**
+     * @var Json
+     */
+    protected $json;
+    /**
+     * @var Monolog
+     */
+    protected $logger;
 
     /**
      * ConfigurablePlugin constructor.
      *
-     * @param Config            $config
-     * @param ProductRepository $product
-     * @param TurnToProduct     $turnToProduct
+     * @param Config $config
+     * @param Json $json
+     * @param Monolog $logger
+     * @param TurnToProduct $turnToProduct
      */
     public function __construct(
         Config $config,
-        ProductRepository $product,
+        Json $json,
+        Monolog $logger,
         TurnToProduct $turnToProduct
     ) {
         $this->config = $config;
-        $this->product = $product;
+        $this->json = $json;
+        $this->logger = $logger;
         $this->turnToProduct = $turnToProduct;
     }
 
     /**
      * @param Configurable $subject
      * @param $result
-     * @return false|string
-     * @throws NoSuchEntityException
+     * @return string
      */
     public function afterGetJsonConfig(
         Configurable $subject,
         $result
-    ) {
-        $result = json_decode($result,true);
-        $parentProduct =  $this->product->getById($result['productId']);
+    ): string {
+        try {
+            $decodedResult = $this->json->unserialize($result);
+        } catch (InvalidArgumentException $e) {
+            $this->logger->error($e->getMessage(), ['exception' => $e]);
+            return $result;
+        }
+
+        if (!is_array($decodedResult) || empty($decodedResult['productId'])) {
+            return $result;
+        }
+
+        $result = $decodedResult;
         $result['useChild'] = $this->config->getUseChildSku();
+
+        $parentProduct = $subject->getProduct();
+        if (!$parentProduct || !$parentProduct->getId()) {
+            return $this->json->serialize($result);
+        }
+
         $result['parentSku'] = $this->turnToProduct->turnToSafeEncoding($parentProduct->getSku());
 
-        $children = $parentProduct->getTypeInstance()->getUsedProducts($parentProduct);
-        if ($children) {
-            $result['childSkuMap'] = [];
-            foreach ($children as $child) {
-                $result['childSkuMap'][$child->getId()] = $this->turnToProduct->turnToSafeEncoding($child->getSku());
+        if ($result['useChild']) {
+            $childSkuMap = $this->buildChildSkuMap($result, $subject);
+            if (!empty($childSkuMap)) {
+                $result['childSkuMap'] = $childSkuMap;
             }
         }
 
-        return json_encode($result);
+        return $this->json->serialize($result);
+    }
+
+    /**
+     * @param array       $jsonConfig
+     * @param Configurable $subject
+     * @return array
+     */
+    protected function buildChildSkuMap(array $jsonConfig, Configurable $subject): array
+    {
+        $childSkuMap = [];
+        if (!empty($jsonConfig['sku']) && is_array($jsonConfig['sku'])) {
+            foreach ($jsonConfig['sku'] as $productId => $sku) {
+                if (!is_scalar($sku)) {
+                    continue;
+                }
+                $childSkuMap[$productId] = $this->turnToProduct->turnToSafeEncoding((string)$sku);
+            }
+            return $childSkuMap;
+        }
+
+        foreach ($subject->getAllowProducts() as $childProduct) {
+            $childSkuMap[$childProduct->getId()] = $this->turnToProduct->turnToSafeEncoding($childProduct->getSku());
+        }
+
+        return $childSkuMap;
     }
 }

--- a/Plugin/Block/Product/View/Type/ConfigurablePlugin.php
+++ b/Plugin/Block/Product/View/Type/ConfigurablePlugin.php
@@ -7,11 +7,11 @@ declare(strict_types=1);
 
 namespace TurnTo\SocialCommerce\Plugin\Block\Product\View\Type;
 
-use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ProductRepository;
 use Magento\ConfigurableProduct\Block\Product\View\Type\Configurable;
 use Magento\Framework\Exception\NoSuchEntityException;
 use TurnTo\SocialCommerce\Model\Config;
+use TurnTo\SocialCommerce\Model\Product as TurnToProduct;
 
 class ConfigurablePlugin
 {
@@ -21,20 +21,29 @@ class ConfigurablePlugin
     protected $config;
 
     /**
-     * @var Product
+     * @var ProductRepository
      */
     protected $product;
+    /**
+     * @var TurnToProduct
+     */
+    protected $turnToProduct;
 
     /**
      * ConfigurablePlugin constructor.
      *
      * @param Config            $config
      * @param ProductRepository $product
+     * @param TurnToProduct     $turnToProduct
      */
-    public function __construct(Config $config, ProductRepository $product)
-    {
+    public function __construct(
+        Config $config,
+        ProductRepository $product,
+        TurnToProduct $turnToProduct
+    ) {
         $this->config = $config;
         $this->product = $product;
+        $this->turnToProduct = $turnToProduct;
     }
 
     /**
@@ -50,13 +59,13 @@ class ConfigurablePlugin
         $result = json_decode($result,true);
         $parentProduct =  $this->product->getById($result['productId']);
         $result['useChild'] = $this->config->getUseChildSku();
-        $result['parentSku'] = $parentProduct->getSku();
+        $result['parentSku'] = $this->turnToProduct->turnToSafeEncoding($parentProduct->getSku());
 
         $children = $parentProduct->getTypeInstance()->getUsedProducts($parentProduct);
         if ($children) {
             $result['childSkuMap'] = [];
             foreach ($children as $child) {
-                $result['childSkuMap'][$child->getId()] = $child->getSku();
+                $result['childSkuMap'][$child->getId()] = $this->turnToProduct->turnToSafeEncoding($child->getSku());
             }
         }
 

--- a/Service/Feed/AbstractFeedGenerator.php
+++ b/Service/Feed/AbstractFeedGenerator.php
@@ -1,0 +1,379 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Service\Feed;
+
+use Exception;
+use LogicException;
+use Magento\Catalog\Api\Data\ProductAttributeInterface;
+use Magento\Catalog\Helper\Image;
+use Magento\Catalog\Model\Category;
+use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Eav\Model\Config as EavConfig;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Store\Api\Data\StoreInterface;
+use TurnTo\SocialCommerce\Api\FeedGeneratorInterface;
+use TurnTo\SocialCommerce\Logger\Monolog;
+use TurnTo\SocialCommerce\Model\Config;
+use TurnTo\SocialCommerce\Model\Config\Gtin;
+use TurnTo\SocialCommerce\Model\Export\CategoryPathResolver;
+use TurnTo\SocialCommerce\Model\Product;
+
+/**
+ * Shared helpers for TurnTo product feed generators (sanitization, GTIN, images, categories).
+ */
+abstract class AbstractFeedGenerator implements FeedGeneratorInterface
+{
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    /**
+     * @var Gtin
+     */
+    protected $gtinConfig;
+
+    /**
+     * @var Image
+     */
+    protected $imageHelper;
+
+    /**
+     * @var Product
+     */
+    protected $product;
+
+    /**
+     * @var EavConfig
+     */
+    protected $eavConfig;
+
+    /**
+     * @var PriceCurrencyInterface
+     */
+    protected $priceCurrency;
+
+    /**
+     * @var Monolog
+     */
+    protected $logger;
+
+    /**
+     * @var CategoryPathResolver
+     */
+    protected $categoryPathResolver;
+
+    /**
+     * @var resource|null
+     */
+    protected $stream;
+
+    /**
+     * @var bool
+     */
+    protected $isFeedOpen = false;
+
+    /**
+     * @param Config $config
+     * @param Gtin $gtinConfig
+     * @param Image $imageHelper
+     * @param Product $product TurnTo product helper (SKU encoding, etc.)
+     * @param EavConfig $eavConfig
+     * @param PriceCurrencyInterface $priceCurrency
+     * @param Monolog $logger
+     * @param CategoryPathResolver $categoryPathResolver
+     */
+    public function __construct(
+        Config $config,
+        Gtin $gtinConfig,
+        Image $imageHelper,
+        Product $product,
+        EavConfig $eavConfig,
+        PriceCurrencyInterface $priceCurrency,
+        Monolog $logger,
+        CategoryPathResolver $categoryPathResolver
+    ) {
+        $this->config = $config;
+        $this->gtinConfig = $gtinConfig;
+        $this->imageHelper = $imageHelper;
+        $this->product = $product;
+        $this->eavConfig = $eavConfig;
+        $this->priceCurrency = $priceCurrency;
+        $this->logger = $logger;
+        $this->categoryPathResolver = $categoryPathResolver;
+    }
+
+    /**
+     * Escapes special characters for xml use
+     *
+     * @param string $dirtyString
+     *
+     * @return string
+     */
+    protected function sanitizeData($dirtyString)
+    {
+        if (is_string($dirtyString)) {
+            return htmlspecialchars($dirtyString, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        }
+        return $dirtyString;
+    }
+
+    /**
+     * Resolves a product attribute value, returning the display label for
+     * EAV select/multiselect attributes instead of the raw option ID.
+     *
+     * @param CatalogProduct $product
+     * @param string $attributeCode
+     * @return string|null
+     */
+    protected function getProductAttributeValue(CatalogProduct $product, string $attributeCode)
+    {
+        if (empty($attributeCode)) {
+            return null;
+        }
+
+        try {
+            $attribute = $this->eavConfig->getAttribute(ProductAttributeInterface::ENTITY_TYPE_CODE, $attributeCode);
+            if ($attribute && $attribute->usesSource()) {
+                $label = $product->getAttributeText($attributeCode);
+                if (is_array($label)) {
+                    return implode(', ', $label);
+                }
+                return (string)$label;
+            }
+        } catch (Exception $e) {
+            $this->logger->error(
+                'Error retrieving product attribute',
+                [
+                    'exception' => $e,
+                    'attributeCode' => $attributeCode,
+                    'productId' => $product->getId()
+                ]
+            );
+        }
+
+        $value = $product->getData($attributeCode);
+        if (is_array($value)) {
+            return implode(', ', array_map('strval', $value));
+        }
+        return !empty($value) ? (string)$value : null;
+    }
+
+    /**
+     * @param CatalogProduct $product
+     * @param array $gtinMap
+     * @return string|null
+     */
+    public function getGtinValue($product, $gtinMap)
+    {
+        $gtinAttributes = [
+            Gtin::UPC_ATTRIBUTE,
+            Gtin::EAN_ATTRIBUTE,
+            Gtin::JAN_ATTRIBUTE,
+            Gtin::ISBN_ATTRIBUTE,
+            Gtin::ASIN_ATTRIBUTE
+        ];
+        foreach ($gtinAttributes as $key) {
+            if (isset($gtinMap[$key])) {
+                return $this->getProductAttributeValue($product, $gtinMap[$key]);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param CatalogProduct $product
+     * @return string
+     */
+    public function getProductImageUrl($product)
+    {
+        $productImageUrl = '';
+        try {
+            $productImage = $product->getImage();
+            if ($productImage) {
+                $productImageUrl = $this->imageHelper->init($product, 'product_page_main_image')
+                    ->setImageFile($productImage)->getUrl();
+            }
+        } catch (Exception $e) {
+            $this->logger->error(
+                'Error retrieving product image',
+                [
+                    'exception' => $e,
+                    'productId' => $product->getId()
+                ]
+            );
+        }
+
+        return $productImageUrl;
+    }
+
+    /**
+     * Gets the deepest tree for given product and returns as "rootNodeName > branchNodeName > leafNodeName"
+     *
+     * @param CatalogProduct $product
+     * @param int|StoreInterface|string $storeId
+     * @return string
+     * @throws LocalizedException
+     */
+    protected function getCategoryTreeString(CatalogProduct $product, $storeId)
+    {
+        $categoryTree = $this->getCategoryPathNodes($product, $storeId);
+        $categoryName = '';
+
+        foreach ($categoryTree as $node) {
+            $nodeName = $node['name'] ?? '';
+            if (!empty($nodeName)) {
+                if (!empty($categoryName)) {
+                    $categoryName .= ' > ';
+                }
+                $categoryName .= $nodeName;
+            }
+        }
+
+        return $categoryName;
+    }
+
+    /**
+     * Gets the category path as arrays using either preloaded resolver data or fallback recursion.
+     *
+     * @param CatalogProduct $product
+     * @param int|StoreInterface|string $storeId
+     * @return array<array{id:string,name:string}>
+     * @throws LocalizedException
+     */
+    protected function getCategoryPathNodes(CatalogProduct $product, $storeId): array
+    {
+        $productId = (int) $product->getId();
+        if ($productId > 0 && $this->categoryPathResolver instanceof CategoryPathResolver) {
+            $categoryPath = $this->categoryPathResolver->getCategoryPath((int) $storeId, $productId);
+            if ($categoryPath !== null) {
+                return $categoryPath;
+            }
+        }
+
+        $categoryTree = $this->getDeepestCategoryTree($product, $storeId);
+        $categoryPath = [];
+        foreach ($categoryTree as $node) {
+            $categoryPath[] = [
+                'id' => (string) $node->getId(),
+                'name' => (string) $node->getName()
+            ];
+        }
+
+        return $categoryPath;
+    }
+
+    /**
+     * Gets the deepest category tree for given product in root-to-leaf order.
+     *
+     * @param CatalogProduct $product
+     * @param int|StoreInterface|string $storeId
+     * @return array
+     * @throws LocalizedException
+     */
+    protected function getDeepestCategoryTree(CatalogProduct $product, $storeId)
+    {
+        $categories = $product->getCategoryCollection()->setStoreId($storeId)->addAttributeToSelect('name');
+        $deepestLength = 0;
+        $deepestTree = [];
+
+        foreach ($categories as $category) {
+            $tempTree = $this->getCategoryBranch($category);
+            $treeLength = count($tempTree);
+            if ($treeLength > $deepestLength) {
+                $deepestLength = $treeLength;
+                $deepestTree = $tempTree;
+            }
+        }
+
+        return array_reverse($deepestTree);
+    }
+
+    /**
+     * Recursively walks category chain from leaf to root while writing the traversed branch to an array
+     *
+     * @param Category $category
+     * @param array $categoryBranch
+     *
+     * @return array
+     */
+    protected function getCategoryBranch(Category $category, array $categoryBranch = [])
+    {
+        try {
+            $parent = $category->getParentCategory();
+        } catch (NoSuchEntityException $isRootEntity) {
+            $parent = null;
+        } finally {
+            $categoryBranch[] = $category;
+            if (isset($parent)) {
+                return $this->getCategoryBranch($parent, $categoryBranch);
+            } else {
+                return $categoryBranch;
+            }
+        }
+    }
+
+    /**
+     * Get item group ID for a given product
+     *
+     * @param CatalogProduct $product
+     * @param CatalogProduct|bool $parent
+     *
+     * @return string
+     */
+    public function getItemGroupId($product, $parent)
+    {
+        if ($parent) {
+            return $this->product->turnToSafeEncoding($parent->getSku());
+        } else {
+            return $this->product->turnToSafeEncoding($product->getSku());
+        }
+    }
+
+    /**
+     * Ensure the feed stream is initialized and valid before reading it back.
+     *
+     * @return void
+     */
+    protected function assertFeedStreamReady(): void
+    {
+        if (!$this->isFeedOpen) {
+            throw new LogicException('Feed stream is not initialized. Call beginFeed() before finishFeed().');
+        }
+
+        if (!is_resource($this->stream)) {
+            $this->cleanupStream();
+            throw new LogicException('Feed stream is invalid. Call beginFeed() again before finishFeed().');
+        }
+    }
+
+    /**
+     * Release stream resources and reset stream state.
+     *
+     * @return void
+     */
+    protected function cleanupStream(): void
+    {
+        if (is_resource($this->stream)) {
+            fclose($this->stream);
+        }
+        $this->isFeedOpen = false;
+        $this->stream = null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isFeedOpen(): bool
+    {
+        return $this->isFeedOpen;
+    }
+}

--- a/Service/Feed/CommerceFeedGenerator.php
+++ b/Service/Feed/CommerceFeedGenerator.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Service\Feed;
+
+use Exception;
+use LogicException;
+use Magento\Catalog\Helper\Image;
+use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Eav\Model\Config as EavConfig;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Store\Api\Data\StoreInterface;
+use TurnTo\SocialCommerce\Logger\Monolog;
+use TurnTo\SocialCommerce\Model\Config;
+use TurnTo\SocialCommerce\Model\Config\Gtin;
+use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
+use TurnTo\SocialCommerce\Model\Export\CategoryPathResolver;
+use TurnTo\SocialCommerce\Model\Export\Product as ExportProduct;
+use TurnTo\SocialCommerce\Model\Product;
+
+/**
+ * Tab-delimited Commerce product feed generator for TurnTo.
+ */
+class CommerceFeedGenerator extends AbstractFeedGenerator
+{
+    /**
+     * @var ExportProduct
+     */
+    protected $exportProduct;
+
+    /**
+     * @param Config $config
+     * @param Gtin $gtinConfig
+     * @param Image $imageHelper
+     * @param Product $product
+     * @param EavConfig $eavConfig
+     * @param PriceCurrencyInterface $priceCurrency
+     * @param Monolog $logger
+     * @param CategoryPathResolver $categoryPathResolver
+     * @param ExportProduct $exportProduct
+     */
+    public function __construct(
+        Config $config,
+        Gtin $gtinConfig,
+        Image $imageHelper,
+        Product $product,
+        EavConfig $eavConfig,
+        PriceCurrencyInterface $priceCurrency,
+        Monolog $logger,
+        CategoryPathResolver $categoryPathResolver,
+        ExportProduct $exportProduct
+    ) {
+        parent::__construct(
+            $config,
+            $gtinConfig,
+            $imageHelper,
+            $product,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $categoryPathResolver
+        );
+        $this->exportProduct = $exportProduct;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getFeedStyle(): string
+    {
+        return FeedFormat::COMMERCE;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function beginFeed(StoreInterface $store)
+    {
+        $this->stream = fopen('php://temp', 'r+');
+        if ($this->stream === false) {
+            $this->isFeedOpen = false;
+            throw new LogicException('Failed to initialize feed stream.');
+        }
+        $this->isFeedOpen = true;
+        $header = implode("\t", [
+            'id', 'title', 'item_url', 'image_url', 'stock', 'active',
+            'category_path_json', 'virtual_parent_code', 'members', 'brand',
+            'currency', 'price', 'upc', 'ean', 'mpn'
+        ]) . "\n";
+        fwrite($this->stream, $header);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addProduct($product, $parent = null, $storeId = null): bool
+    {
+        try {
+            $line = $this->generateProductLine($product, $storeId, $parent);
+            if ($line) {
+                if (fwrite($this->stream, $line . "\n") === false) {
+                    $this->logger->error(
+                        'Failed to write product to feed',
+                        [
+                            'product_id' => $product->getId(),
+                            'store_id' => $storeId
+                        ]
+                    );
+                    return false;
+                }
+                return true;
+            }
+        } catch (Exception $entryException) {
+            $this->logger->error(
+                'Product failed to be added to feed',
+                [
+                    'exception' => $entryException,
+                    'productSKU' => $product->getSku()
+                ]
+            );
+            return false;
+        }
+
+        return false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function finishFeed()
+    {
+        $this->assertFeedStreamReady();
+
+        try {
+            rewind($this->stream);
+            $content = stream_get_contents($this->stream);
+        } finally {
+            $this->cleanupStream();
+        }
+
+        return $content;
+    }
+
+    /**
+     * Sanitize text fields for tab-delimited feeds to prevent column/row shifting.
+     *
+     * @param string|null $text
+     * @return string
+     */
+    protected function sanitizeTextField(?string $text): string
+    {
+        if ($text === null || $text === '') {
+            return '';
+        }
+
+        return trim(preg_replace('/[\t\r\n]+/', ' ', $text));
+    }
+
+    /**
+     * Build one tab-separated line for the commerce feed.
+     *
+     * @param CatalogProduct $product
+     * @param int|string|null $storeId
+     * @param bool|CatalogProduct|null $parent
+     * @return string
+     * @throws Exception
+     */
+    protected function generateProductLine($product, $storeId, $parent)
+    {
+        if (empty($product)) {
+            throw new Exception('Product can not be null or empty');
+        }
+
+        $sku = $this->product->turnToSafeEncoding($product->getSku());
+        if (empty($sku)) {
+            throw new Exception('Product must have a valid sku');
+        }
+
+        $productUrl = $parent ? $this->exportProduct->getProductUrl($parent, $storeId) : $this->exportProduct->getProductUrl($product, $storeId);
+        if (empty($productUrl)) {
+            throw new Exception('Product must have a valid store-product url');
+        }
+
+        $productName = $product->getName();
+        if (empty($productName)) {
+            throw new Exception('Product must have a valid name');
+        }
+        $productName = $this->sanitizeTextField($productName);
+
+        $turntoDisable = $product->getCustomAttribute('turnto_disabled') ?
+            $product->getCustomAttribute('turnto_disabled')->getValue() :
+            false;
+        $active = $turntoDisable ? '0' : (($product->getStatus() == Status::STATUS_ENABLED) ? '1' : '0');
+
+        $stock = '0';
+        $isInStock = (bool) $product->getData('is_in_stock');
+        if ($isInStock) {
+            $qty = (float) $product->getData('qty');
+            $stock = (string)(int)$qty;
+        }
+
+        $categoryPathJson = '';
+        $categoryTree = $this->getCategoryPathNodes($product, $storeId);
+        $catArray = [];
+        foreach ($categoryTree as $category) {
+            $categoryName = $category['name'] ?? '';
+            if (!empty($categoryName)) {
+                $catArray[] = [
+                    'id' => (string) $category['id'],
+                    'name' => $categoryName
+                ];
+            }
+        }
+        if (!empty($catArray)) {
+            $categoryPathJson = json_encode($catArray);
+        }
+
+        $virtualParentCode = '';
+        $itemGroupId = $this->getItemGroupId($product, $parent);
+        if ($itemGroupId !== $sku) {
+            $virtualParentCode = $itemGroupId;
+        }
+
+        $members = $this->getMembers($product);
+
+        $brand = '';
+        $upc = '';
+        $ean = '';
+        $mpn = '';
+        $gtinMap = $this->gtinConfig->getGtinAttributesMap($storeId);
+        if (!empty($gtinMap)) {
+            if (isset($gtinMap[Gtin::BRAND_ATTRIBUTE])) {
+                $brand = $this->sanitizeTextField((string) $this->getProductAttributeValue($product, $gtinMap[Gtin::BRAND_ATTRIBUTE]));
+            }
+            if (isset($gtinMap[Gtin::UPC_ATTRIBUTE])) {
+                $upc = $this->sanitizeTextField((string) $this->getProductAttributeValue($product, $gtinMap[Gtin::UPC_ATTRIBUTE]));
+            }
+            if (isset($gtinMap[Gtin::EAN_ATTRIBUTE])) {
+                $ean = $this->sanitizeTextField((string) $this->getProductAttributeValue($product, $gtinMap[Gtin::EAN_ATTRIBUTE]));
+            }
+            if (isset($gtinMap[Gtin::MPN_ATTRIBUTE])) {
+                $mpn = $this->sanitizeTextField((string) $this->getProductAttributeValue($product, $gtinMap[Gtin::MPN_ATTRIBUTE]));
+            }
+        }
+
+        $price = $this->priceCurrency->convertAndRound($product->getFinalPrice(), $storeId);
+        $currencyCode = $this->priceCurrency->getCurrency($storeId)->getCurrencyCode();
+
+        $data = [
+            $sku,
+            $productName,
+            $productUrl,
+            $this->getProductImageUrl($product),
+            $stock,
+            $active,
+            $categoryPathJson,
+            $virtualParentCode,
+            $members,
+            $brand,
+            $currencyCode,
+            $price,
+            $upc,
+            $ean,
+            $mpn
+        ];
+
+        return implode("\t", $data);
+    }
+
+    /**
+     * @param CatalogProduct $product
+     * @return string
+     */
+    protected function getMembers($product)
+    {
+        $members = [];
+        $typeId = $product->getTypeId();
+
+        try {
+            if ($typeId === 'bundle') {
+                $selections = $product->getTypeInstance()->getSelectionsCollection(
+                    $product->getTypeInstance()->getOptionsIds($product),
+                    $product
+                );
+                foreach ($selections as $selection) {
+                    $members[] = $this->product->turnToSafeEncoding($selection->getSku());
+                }
+            } elseif ($typeId === 'grouped') {
+                $associatedProducts = $product->getTypeInstance()->getAssociatedProducts($product);
+                foreach ($associatedProducts as $child) {
+                    $members[] = $this->product->turnToSafeEncoding($child->getSku());
+                }
+            }
+        } catch (Exception $e) {
+            $this->logger->error(
+                'Error retrieving members for product',
+                [
+                    'exception' => $e,
+                    'productId' => $product->getId()
+                ]
+            );
+        }
+
+        return implode(',', array_unique($members));
+    }
+}

--- a/Service/Feed/FeedGeneratorFactory.php
+++ b/Service/Feed/FeedGeneratorFactory.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Service\Feed;
+
+use InvalidArgumentException;
+use TurnTo\SocialCommerce\Api\FeedGeneratorInterface;
+
+class FeedGeneratorFactory
+{
+    /**
+     * @var array
+     */
+    protected $generators;
+
+    /**
+     * @param array $generators
+     */
+    public function __construct(array $generators = [])
+    {
+        $this->generators = $generators;
+    }
+
+    /**
+     * @param string|null $format
+     * @return FeedGeneratorInterface
+     * @throws InvalidArgumentException
+     */
+    public function create(?string $format)
+    {
+        if ($format === null || !array_key_exists($format, $this->generators)) {
+            throw new InvalidArgumentException('Invalid feed format: ' . ($format ?? 'null'));
+        }
+
+        $factory = $this->generators[$format];
+        $generator = $factory->create();
+
+        if (!$generator instanceof FeedGeneratorInterface) {
+            throw new InvalidArgumentException(
+                get_class($generator) . ' doesn\'t implement \TurnTo\SocialCommerce\Api\FeedGeneratorInterface'
+            );
+        }
+
+        return $generator;
+    }
+}

--- a/Service/Feed/GoogleFeedGenerator.php
+++ b/Service/Feed/GoogleFeedGenerator.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Service\Feed;
+
+use DateTimeZone;
+use Exception;
+use LogicException;
+use Magento\Catalog\Helper\Image;
+use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Eav\Model\Config as EavConfig;
+use Magento\Framework\Intl\DateTimeFactory;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Api\Data\StoreInterface;
+use SimpleXMLElement;
+use TurnTo\SocialCommerce\Logger\Monolog;
+use TurnTo\SocialCommerce\Model\Config;
+use TurnTo\SocialCommerce\Model\Config\Gtin;
+use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
+use TurnTo\SocialCommerce\Model\Export\CategoryPathResolver;
+use TurnTo\SocialCommerce\Model\Export\Product as ExportProduct;
+use TurnTo\SocialCommerce\Model\Product;
+
+/**
+ * Google Shopping Atom 1.0 product feed generator.
+ */
+class GoogleFeedGenerator extends AbstractFeedGenerator
+{
+    /**
+     * @var DateTimeFactory
+     */
+    protected $dateTimeFactory;
+
+    /**
+     * @var ExportProduct
+     */
+    protected $exportProduct;
+
+    /**
+     * @param Config $config
+     * @param Gtin $gtinConfig
+     * @param Image $imageHelper
+     * @param Product $product
+     * @param EavConfig $eavConfig
+     * @param PriceCurrencyInterface $priceCurrency
+     * @param Monolog $logger
+     * @param DateTimeFactory $dateTimeFactory
+     * @param CategoryPathResolver $categoryPathResolver
+     * @param ExportProduct $exportProduct Resolves storefront product URLs for feed links
+     */
+    public function __construct(
+        Config $config,
+        Gtin $gtinConfig,
+        Image $imageHelper,
+        Product $product,
+        EavConfig $eavConfig,
+        PriceCurrencyInterface $priceCurrency,
+        Monolog $logger,
+        DateTimeFactory $dateTimeFactory,
+        CategoryPathResolver $categoryPathResolver,
+        ExportProduct $exportProduct
+    ) {
+        parent::__construct(
+            $config,
+            $gtinConfig,
+            $imageHelper,
+            $product,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $categoryPathResolver
+        );
+        $this->dateTimeFactory = $dateTimeFactory;
+        $this->exportProduct = $exportProduct;
+    }
+
+
+    /**
+     * @inheritdoc
+     */
+    public function getFeedStyle(): string
+    {
+        return FeedFormat::GOOGLE_PRODUCT;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function beginFeed(StoreInterface $store)
+    {
+        $this->stream = fopen('php://temp', 'r+');
+        if ($this->stream === false) {
+            $this->isFeedOpen = false;
+            throw new LogicException('Failed to initialize feed stream.');
+        }
+        $this->isFeedOpen = true;
+        $header = '<?xml version="1.0" encoding="UTF-8"?>' . "\n" .
+                  '<feed xmlns="http://www.w3.org/2005/Atom" xmlns:g="http://base.google.com/ns/1.0" xml:lang="en-US">' . "\n" .
+                  '<title>' . $this->sanitizeData($store->getName() . ' - Google Product Atom 1.0 Feed') . '</title>' . "\n" .
+                  '<link>' . $this->sanitizeData($store->getBaseUrl(UrlInterface::URL_TYPE_LINK)) . '</link>' . "\n" .
+                  '<updated>' . $this->dateTimeFactory->create('now', new DateTimeZone('UTC'))->format(DATE_ATOM) . '</updated>' . "\n" .
+                  '<author><name>TurnTo</name></author>' . "\n" .
+                  '<id>' . $this->sanitizeData($store->getBaseUrl(UrlInterface::URL_TYPE_WEB)) . '</id>' . "\n";
+        fwrite($this->stream, $header);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addProduct($product, $parent = null, $storeId = null): bool
+    {
+        try {
+            $entry = new SimpleXMLElement('<entry xmlns="http://www.w3.org/2005/Atom" xmlns:g="http://base.google.com/ns/1.0"/>');
+            $this->addProductToAtomFeed($entry, $product, $storeId, $parent);
+            $entryXml = $entry->asXML();
+            $entryXml = str_replace(
+                ['<?xml version="1.0"?>', ' xmlns="http://www.w3.org/2005/Atom"', ' xmlns:g="http://base.google.com/ns/1.0"'],
+                '',
+                $entryXml
+            );
+            if (fwrite($this->stream, trim($entryXml) . "\n") === false) {
+                $this->logger->error(
+                    'Failed to write product to feed',
+                    [
+                        'product_id' => $product->getId(),
+                        'store_id' => $storeId
+                    ]
+                );
+                return false;
+            }
+            return true;
+        } catch (Exception $e) {
+            $this->logger->error(
+                'Product failed to be added to feed',
+                [
+                    'exception' => $e,
+                    'productSKU' => $product->getSku()
+                ]
+            );
+        }
+
+        return false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function finishFeed()
+    {
+        $this->assertFeedStreamReady();
+
+        try {
+            fwrite($this->stream, '</feed>');
+            rewind($this->stream);
+            $content = stream_get_contents($this->stream);
+        } finally {
+            $this->cleanupStream();
+        }
+
+        return $content;
+    }
+
+    /**
+     * Adds a Magento catalog product to a Google Products ATOM 1.0 xml feed
+     *
+     * @param SimpleXMLElement $entry
+     * @param CatalogProduct $product
+     * @param int|string $storeId
+     * @param bool|CatalogProduct $parent
+     * @return void
+     * @throws Exception
+     */
+    protected function addProductToAtomFeed($entry, $product, $storeId, $parent)
+    {
+        if (empty($product)) {
+            throw new Exception('Product can not be null or empty');
+        }
+
+        $sku = $this->product->turnToSafeEncoding($product->getSku());
+        if (empty($sku)) {
+            throw new Exception('Product must have a valid sku');
+        }
+
+        $productUrl = $parent ? $this->exportProduct->getProductUrl($parent, $storeId) : $this->exportProduct->getProductUrl($product, $storeId);
+        if (empty($productUrl)) {
+            throw new Exception('Product must have a valid store-product url');
+        }
+
+        $productName = $product->getName();
+        if (empty($productName)) {
+            throw new Exception('Product must have a valid name');
+        }
+        $productName = str_replace("\n", "", $productName);
+
+        $entry->addChild('id', $this->sanitizeData($sku));
+
+        $identifierExists = 'FALSE';
+        $gtinMap = $this->gtinConfig->getGtinAttributesMap($storeId);
+        $gNs = 'http://base.google.com/ns/1.0';
+        if (!empty($gtinMap)) {
+            $gtinValue = $this->getGtinValue($product, $gtinMap);
+            if (!empty($gtinValue)) {
+                $entry->addChild('g:gtin', $this->sanitizeData($gtinValue), $gNs);
+            }
+            $brand = null;
+            if (isset($gtinMap[Gtin::BRAND_ATTRIBUTE])) {
+                $brand = $this->getProductAttributeValue($product, $gtinMap[Gtin::BRAND_ATTRIBUTE]);
+                if (!empty($brand)) {
+                    $entry->addChild('g:brand', $this->sanitizeData($brand), $gNs);
+                }
+            }
+            $mpn = null;
+            if (isset($gtinMap[Gtin::MPN_ATTRIBUTE])) {
+                $mpn = $this->getProductAttributeValue($product, $gtinMap[Gtin::MPN_ATTRIBUTE]);
+                if (!empty($mpn)) {
+                    $entry->addChild('g:mpn', $this->sanitizeData($mpn), $gNs);
+                }
+            }
+            if (!empty($brand) && (!empty($gtinValue) || !empty($mpn))) {
+                $identifierExists = 'TRUE';
+            }
+        }
+
+        $entry->addChild('g:identifier_exists', $identifierExists, $gNs);
+        $entry->addChild('g:link', $this->sanitizeData($productUrl), $gNs);
+        $entry->addChild('g:title', $this->sanitizeData($productName), $gNs);
+
+        $categoryName = $this->getCategoryTreeString($product, $storeId);
+        if (!empty($categoryName)) {
+            $cleanCategoryName = $this->sanitizeData($categoryName);
+            $entry->addChild('g:google_product_category', $cleanCategoryName, $gNs);
+            $entry->addChild('g:product_type', $cleanCategoryName, $gNs);
+        }
+
+        // Availability is normally determined by status, but can be overridden by custom "turnto_disabled" attribute
+        $turntoDisable = $product->getCustomAttribute('turnto_disabled') ?
+            $product->getCustomAttribute('turnto_disabled')->getValue() :
+            false;
+        $availability = $turntoDisable ? 'out of stock' :
+            (($product->getStatus() == Status::STATUS_ENABLED) ? 'in stock' : 'out of stock');
+
+        $entry->addChild('g:availability', $availability, $gNs);
+        $productImageUrl = $this->getProductImageUrl($product);
+        $entry->addChild('g:image_link', $this->sanitizeData($productImageUrl), $gNs);
+        $entry->addChild('g:condition', 'new', $gNs);
+        $price = $this->priceCurrency->convertAndRound($product->getFinalPrice(), $storeId);
+        $currencyCode = $this->priceCurrency->getCurrency($storeId)->getCurrencyCode();
+        $entry->addChild('g:price', $price . ' ' . $currencyCode, $gNs);
+        $itemGroupId = $this->getItemGroupId($product, $parent);
+        $entry->addChild('g:item_group_id', $this->sanitizeData($itemGroupId), $gNs);
+    }
+}

--- a/Service/FirebaseJwt.php
+++ b/Service/FirebaseJwt.php
@@ -7,6 +7,8 @@ declare(strict_types=1);
 
 namespace TurnTo\SocialCommerce\Service;
 
+use RuntimeException;
+use InvalidArgumentException;
 use TurnTo\SocialCommerce\Api\JwtInterface;
 use TurnTo\SocialCommerce\Model\Config;
 use TurnTo\SocialCommerce\Service\FirebaseJwt\JWT;
@@ -36,10 +38,13 @@ class FirebaseJwt implements JwtInterface
      */
     public function getJwt($payload)
     {
-        if(empty($payload)) {
-            return "Invalid payload";
+        if (!is_array($payload) || empty($payload)) {
+            throw new InvalidArgumentException('Invalid payload');
         }
         $key = $this->config->getAuthorizationKey();
+        if (empty($key)) {
+            throw new RuntimeException('Missing authorization key');
+        }
 
         return $this->jwt->encode($payload, $key, 'HS256');
     }

--- a/Service/GoogleFeed/Client.php
+++ b/Service/GoogleFeed/Client.php
@@ -9,11 +9,14 @@ namespace TurnTo\SocialCommerce\Service\GoogleFeed;
 
 use Exception;
 use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\RequestOptions;
+use SimpleXMLElement;
 use TurnTo\SocialCommerce\Api\FeedClient;
 use TurnTo\SocialCommerce\Model\Config;
 use TurnTo\SocialCommerce\Logger\Monolog;
-use TurnTo\SocialCommerce\Model\Export\Catalog;
+use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
 use TurnTo\SocialCommerce\Model\File;
 
 class Client implements FeedClient
@@ -22,6 +25,11 @@ class Client implements FeedClient
      * Response body from TurnTo servers on successful operation
      */
     const TURNTO_SUCCESS_RESPONSE = 'SUCCESS';
+    const MAX_TRANSMISSION_ATTEMPTS = 3;
+    /**
+     * 500ms base retry delay, doubled for each retry attempt.
+     */
+    const TRANSMISSION_RETRY_DELAY_MICROSECONDS = 500000;
     /**
      * @var Config
      */
@@ -53,58 +61,127 @@ class Client implements FeedClient
 
     /**
      * @inheritdoc
+     * @throws GuzzleException
      */
     public function transmitFeedFile($feedData, string $fileName, string $feedStyle, string $storeCode)
     {
-        $responseContents = 'win';
-        try {
-            if ($feedStyle === Catalog::FEED_STYLE) {
-                $feedData = $feedData->asXML();
-                $path = "turnto/google-product_storecode_{$storeCode}.xml";
-                $this->file->writeFile($path, $feedData);
-            }
+        for ($attempt = 1; $attempt <= self::MAX_TRANSMISSION_ATTEMPTS; $attempt++) {
+            $responseContents = '';
+            $statusCode = null;
+            $shouldRetry = false;
+            $transmissionContext = [
+                'store_code' => $storeCode,
+                'feed_style' => $feedStyle,
+                'file_name' => $fileName,
+                'attempt' => $attempt,
+                'max_attempts' => self::MAX_TRANSMISSION_ATTEMPTS
+            ];
 
-            $response = $this->client->request('POST', $this->config->getConfigValue(Config::PRODUCT_FEED_SUBMISSION_URL, $storeCode), [
-                RequestOptions::MULTIPART => [
+            try {
+                if ($feedStyle === FeedFormat::GOOGLE_PRODUCT) {
+                    if ($feedData instanceof SimpleXMLElement) {
+                        $feedData = $feedData->asXML();
+                    }
+                    $path = "turnto/google-product_storecode_$storeCode.xml";
+                    $this->file->writeFile($path, $feedData);
+                } elseif ($feedStyle === FeedFormat::COMMERCE) {
+                    $path = "turnto/commerce-product_storecode_$storeCode.tsv";
+                    $this->file->writeFile($path, $feedData);
+                }
+
+                $response = $this->client->request(
+                    'POST',
+                    $this->config->getConfigValue(Config::PRODUCT_FEED_SUBMISSION_URL, $storeCode),
                     [
-                        'name' => 'siteKey',
-                        'contents' => $this->config->getSiteKey($storeCode)
-                    ],
-                    [
-                        'name' => 'authKey',
-                        'contents' => $this->config->getAuthorizationKey($storeCode)
-                    ],
-                    [
-                        'name' => 'feedStyle',
-                        'contents' => $feedStyle
-                    ],
-                    [
-                        'name'     => 'file',
-                        'contents' => $feedData,
-                        'filename' => $fileName
+                        RequestOptions::HTTP_ERRORS => false,
+                        RequestOptions::MULTIPART => [
+                            [
+                                'name' => 'siteKey',
+                                'contents' => $this->config->getSiteKey($storeCode)
+                            ],
+                            [
+                                'name' => 'authKey',
+                                'contents' => $this->config->getAuthorizationKey($storeCode)
+                            ],
+                            [
+                                'name' => 'feedStyle',
+                                'contents' => $feedStyle
+                            ],
+                            [
+                                'name' => 'file',
+                                'contents' => $feedData,
+                                'filename' => $fileName
+                            ]
+                        ]
                     ]
-                ]
-            ]);
+                );
 
-            $responseContents = $response->getBody()->getContents();
-            if ($feedStyle === Catalog::FEED_STYLE) {
-                $path = "turnto/google-product_storecode_{$storeCode}_request.xml";
-                $this->file->writeFile($path, $responseContents);
-            }
+                $statusCode = $response->getStatusCode();
+                $responseContents = $response->getBody()->getContents();
 
-            //It is possible to get a status 200 message who's body is an error message from TurnTo
-            if ($responseContents !== self::TURNTO_SUCCESS_RESPONSE) {
-                throw new Exception("Emplifi $fileName submission failed with message: $responseContents");
+                if ($feedStyle === FeedFormat::GOOGLE_PRODUCT) {
+                    $path = "turnto/google-product_storecode_{$storeCode}_request.xml";
+                    $this->file->writeFile($path, $responseContents);
+                } elseif ($feedStyle === FeedFormat::COMMERCE) {
+                    $path = "turnto/commerce-product_storecode_{$storeCode}_request.txt";
+                    $this->file->writeFile($path, $responseContents);
+                }
+
+                if ($statusCode < 200 || $statusCode >= 300) {
+                    $shouldRetry = $statusCode === 429 || ($statusCode >= 500 && $statusCode < 600);
+                    throw new Exception(sprintf(
+                        'Emplifi %s submission failed with status %d and response %s',
+                        $fileName,
+                        $statusCode,
+                        $responseContents
+                    ));
+                }
+
+                if (trim($responseContents) !== self::TURNTO_SUCCESS_RESPONSE) {
+                    throw new Exception(sprintf(
+                        'Emplifi %s submission failed with message: %s',
+                        $fileName,
+                        $responseContents
+                    ));
+                }
+
+                return;
+            } catch (Exception $e) {
+                if ($e instanceof TransferException) {
+                    $shouldRetry = true;
+                }
+
+                $transmissionContext['exception'] = $e;
+                $transmissionContext['status_code'] = $statusCode;
+                $transmissionContext['response'] = $responseContents;
+                if ($shouldRetry && $attempt < self::MAX_TRANSMISSION_ATTEMPTS) {
+                    $this->logger->warning(
+                        'TurnTo catalog export transmission failed; retrying',
+                        $transmissionContext
+                    );
+                    usleep($this->getRetryDelayMicroseconds($attempt));
+                    continue;
+                }
+
+                $this->logger->error(
+                    'TurnTo catalog feed transmission failed',
+                    $transmissionContext
+                );
+
+                throw $e;
             }
-        } catch (Exception $e) {
-            $this->logger->error(
-                "An error occurred while transmitting $fileName to TurnTo. Error: ",
-                [
-                    'exception' => $e,
-                    'response' => $responseContents
-                ]
-            );
-            throw $e;
         }
+    }
+
+    /**
+     * Backoff in microseconds for a retry attempt.
+     * attempt value starts at 1.
+     *
+     * @param int $attempt
+     * @return int
+     */
+    protected function getRetryDelayMicroseconds(int $attempt): int
+    {
+        return self::TRANSMISSION_RETRY_DELAY_MICROSECONDS * (1 << ($attempt - 1));
     }
 }

--- a/Test/Unit/Model/Export/CatalogTest.php
+++ b/Test/Unit/Model/Export/CatalogTest.php
@@ -190,6 +190,7 @@ class CatalogTest extends TestCase
         $collection->method('setOrder')->willReturnSelf();
         $collection->method('setPage')->willReturnSelf();
         $collection->method('joinField')->willReturnSelf();
+        $collection->method('joinTable')->willReturnSelf();
         $collection->method('addStoreFilter')->willReturnSelf();
         $collection->method('addFieldToFilter')->willReturnSelf();
         $collection->method('getIterator')->willReturn(new ArrayIterator($products));
@@ -542,5 +543,81 @@ class CatalogTest extends TestCase
 
         $this->catalog = $this->createCatalog();
         $this->catalog->cronUploadFeed();
+    }
+
+    public function testCronUploadFeedTransmitsOnePartPerPageBatchEvenWhenNoProductsAreWritten()
+    {
+        $storeId = 1;
+        $store = $this->createStore($storeId);
+
+        $this->storeManager->method('getStores')->willReturn([$store]);
+        $this->configValues[ConfigModel::PRODUCT_FEED_SUBMISSION_URL] = 'https://feed.test/upload';
+
+        $totalPages = 21;
+        $createInvocation = 0;
+        $this->collectionFactory->method('create')->willReturnCallback(
+            function () use (&$createInvocation, $totalPages) {
+                $createInvocation++;
+                $product = $this->createMock(CatalogProduct::class);
+                $product->method('getId')->willReturn($createInvocation);
+                $product->method('getSku')->willReturn('SKU' . $createInvocation);
+                $product->method('getTypeId')->willReturn('simple');
+
+                return $this->createProductCollection([$product], $totalPages);
+            }
+        );
+
+        $generator = $this->createMock(FeedGeneratorInterface::class);
+        $generator->method('getFeedStyle')->willReturn(FeedFormat::COMMERCE);
+        $isFeedOpen = false;
+        $generator->method('isFeedOpen')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                return $isFeedOpen;
+            }
+        );
+        $generator->expects($this->exactly(2))->method('beginFeed')->with($store)->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = true;
+            }
+        );
+        $generator->expects($this->exactly(21))->method('addProduct')->willReturn(false);
+        $generator->expects($this->exactly(2))->method('finishFeed')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = false;
+
+                return 'feed-placeholder';
+            }
+        );
+        $this->feedGeneratorFactory->method('create')->with(FeedFormat::COMMERCE)->willReturn($generator);
+
+        $fileNames = [];
+        $this->feedClient->expects($this->exactly(2))
+            ->method('transmitFeedFile')
+            ->willReturnCallback(
+                function ($feedData, $fileName) use (&$fileNames) {
+                    $fileNames[] = $fileName;
+
+                    return null;
+                }
+            );
+
+        $this->exportProduct->expects($this->exactly(21))->method('preloadRewriteUrls');
+        $this->categoryPathResolver->expects($this->exactly(21))->method('preloadCategoryPaths');
+        $this->logger->expects($this->never())->method('error');
+        $this->emulation->expects($this->once())
+            ->method('startEnvironmentEmulation')
+            ->with($storeId, Area::AREA_FRONTEND, true);
+        $this->emulation->expects($this->once())->method('stopEnvironmentEmulation');
+
+        $this->catalog = $this->createCatalog();
+        $this->catalog->cronUploadFeed();
+
+        $this->assertSame(
+            [
+                '1_of_2_store_1_' . FeedFormat::COMMERCE,
+                '2_of_2_store_1_' . FeedFormat::COMMERCE,
+            ],
+            $fileNames
+        );
     }
 }

--- a/Test/Unit/Model/Export/CatalogTest.php
+++ b/Test/Unit/Model/Export/CatalogTest.php
@@ -7,27 +7,27 @@ declare(strict_types=1);
 
 namespace TurnTo\SocialCommerce\Test\Unit\Model\Export;
 
-use Magento\Catalog\Helper\Image;
+use Exception;
+use ArrayIterator;
 use Magento\Catalog\Model\Product as CatalogProduct;
-use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
-use Magento\Directory\Model\Currency;
-use Magento\Framework\Intl\DateTimeFactory;
-use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Framework\App\Area;
 use Magento\Store\Model\App\Emulation;
 use Magento\Store\Model\StoreManagerInterface;
-use Magento\Eav\Model\Config as EavConfig;
-use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
-use PHPUnit\Framework\MockObject\Exception;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Framework\App\ResourceConnection;
 use PHPUnit\Framework\TestCase;
-use SimpleXMLElement;
 use TurnTo\SocialCommerce\Api\FeedClient;
+use TurnTo\SocialCommerce\Api\FeedGeneratorInterface;
 use TurnTo\SocialCommerce\Model\Config as ConfigModel;
+use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
 use TurnTo\SocialCommerce\Model\Config\Gtin;
-use TurnTo\SocialCommerce\Model\Product;
 use TurnTo\SocialCommerce\Logger\Monolog;
 use TurnTo\SocialCommerce\Model\Export\Catalog;
-use TurnTo\SocialCommerce\Test\Unit\Model\Export\TestableCatalog;
+use TurnTo\SocialCommerce\Model\Export\CategoryPathResolver;
+use TurnTo\SocialCommerce\Model\Export\Product;
+use TurnTo\SocialCommerce\Service\Feed\FeedGeneratorFactory;
 
 class CatalogTest extends TestCase
 {
@@ -35,193 +35,503 @@ class CatalogTest extends TestCase
      * @var Catalog
      */
     protected $catalog;
-
     /**
-     * @var EavConfig
+     * @var ConfigModel
      */
-    protected $eavConfig;
-
+    protected $config;
     /**
-     * Is called before running a test
-     * @throws Exception
+     * @var Gtin
      */
+    protected $gtin;
+    /**
+     * @var StoreManagerInterface
+     */
+    protected $storeManager;
+    /**
+     * @var array
+     */
+    protected $configValues = [];
+    /**
+     * @var string
+     */
+    protected $feedFormat = FeedFormat::COMMERCE;
+    /**
+     * @var string
+     */
+    protected $siteKey = 'site-key';
+    /**
+     * @var string
+     */
+    protected $authorizationKey = 'auth-key';
+    /**
+     * @var bool
+     */
+    protected $useChildSku = false;
+    /**
+     * @var CollectionFactory
+     */
+    protected $collectionFactory;
+    /**
+     * @var FeedClient
+     */
+    protected $feedClient;
+    /**
+     * @var Emulation
+     */
+    protected $emulation;
+    /**
+     * @var Monolog
+     */
+    protected $logger;
+    /**
+     * @var FeedGeneratorFactory
+     */
+    protected $feedGeneratorFactory;
+    /**
+     * @var ResourceConnection
+     */
+    protected $resourceConnection;
+    /**
+     * @var Product
+     */
+    protected $exportProduct;
+    /**
+     * @var CategoryPathResolver
+     */
+    protected $categoryPathResolver;
+
     protected function setUp(): void
     {
-        $config = $this->createMock(ConfigModel::class);
-        $gtin = $this->createMock(Gtin::class);
-        $storeManager = $this->createMock(StoreManagerInterface::class);
-        $collectionFactory = $this->createMock(CollectionFactory::class);
-        $dateTimeFactory = $this->createMock(DateTimeFactory::class);
-        $imageHelper = $this->createMock(Image::class);
-        $turntoProduct = $this->createMock(Product::class);
-        $this->eavConfig = $this->createMock(EavConfig::class);
-        $feedClient = $this->createMock(FeedClient::class);
-        $emulation = $this->createMock(Emulation::class);
-        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
-        $logger = $this->createMock(Monolog::class);
+        $this->config = $this->createMock(ConfigModel::class);
+        $this->gtin = $this->createMock(Gtin::class);
+        $this->storeManager = $this->createMock(StoreManagerInterface::class);
+        $this->collectionFactory = $this->createMock(CollectionFactory::class);
+        $this->feedClient = $this->createMock(FeedClient::class);
+        $this->emulation = $this->createMock(Emulation::class);
+        $this->logger = $this->createMock(Monolog::class);
+        $this->feedGeneratorFactory = $this->createMock(FeedGeneratorFactory::class);
+        $this->resourceConnection = $this->createMock(ResourceConnection::class);
+        $this->exportProduct = $this->createMock(Product::class);
+        $this->categoryPathResolver = $this->createMock(CategoryPathResolver::class);
+
+        $this->configValues = [
+            ConfigModel::PRODUCT_ENABLE_AUTOMATIC_SUBMISSION => true,
+            ConfigModel::PRODUCT_FEED_SUBMISSION_URL => 'https://feed.test/upload'
+        ];
+
+        $this->config->method('getConfigValue')->willReturnCallback(
+            function ($path, $scopeCode = null) {
+                return $this->configValues[$path] ?? null;
+            }
+        );
+        $this->config->method('getFeedFormat')->willReturnCallback(function ($storeId = null) {
+            return $this->feedFormat;
+        });
+        $this->config->method('getSiteKey')->willReturnCallback(function ($storeId = null) {
+            return $this->siteKey;
+        });
+        $this->config->method('getAuthorizationKey')->willReturnCallback(function ($storeId = null) {
+            return $this->authorizationKey;
+        });
+        $this->config->method('getUseChildSku')->willReturnCallback(function ($storeId = null) {
+            return $this->useChildSku;
+        });
+        $this->config->method('getIsEnabled')->willReturn(true);
+
+        $this->gtin->method('getGtinAttributesMap')->willReturn([]);
 
         $this->catalog = new Catalog(
-            $config,
-            $gtin,
-            $storeManager,
-            $collectionFactory,
-            $dateTimeFactory,
-            $imageHelper,
-            $turntoProduct,
-            $this->eavConfig,
-            $feedClient,
-            $emulation,
-            $priceCurrency,
-            $logger
+            $this->config,
+            $this->gtin,
+            $this->storeManager,
+            $this->collectionFactory,
+            $this->feedClient,
+            $this->emulation,
+            $this->logger,
+            $this->feedGeneratorFactory,
+            $this->resourceConnection,
+            $this->exportProduct,
+            $this->categoryPathResolver
         );
     }
 
-    public function testIsCatalogClass(){
+    protected function createCatalog()
+    {
+        return new Catalog(
+            $this->config,
+            $this->gtin,
+            $this->storeManager,
+            $this->collectionFactory,
+            $this->feedClient,
+            $this->emulation,
+            $this->logger,
+            $this->feedGeneratorFactory,
+            $this->resourceConnection,
+            $this->exportProduct,
+            $this->categoryPathResolver
+        );
+    }
+
+    protected function createProductCollection(array $products, int $totalPages = 1)
+    {
+        $collection = $this->createMock(Collection::class);
+        $collection->method('setStoreId')->willReturnSelf();
+        $collection->method('addAttributeToSelect')->willReturnSelf();
+        $collection->method('addUrlRewrite')->willReturnSelf();
+        $collection->method('setOrder')->willReturnSelf();
+        $collection->method('setPage')->willReturnSelf();
+        $collection->method('joinField')->willReturnSelf();
+        $collection->method('addStoreFilter')->willReturnSelf();
+        $collection->method('addFieldToFilter')->willReturnSelf();
+        $collection->method('getIterator')->willReturn(new ArrayIterator($products));
+        $collection->method('clear')->willReturnSelf();
+        $collection->method('getLastPageNumber')->willReturn($totalPages);
+
+        return $collection;
+    }
+
+    protected function createStore(int $storeId = 1, string $storeCode = 'default')
+    {
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('getId')->willReturn($storeId);
+        $store->method('getCode')->willReturn($storeCode);
+        return $store;
+    }
+
+    public function testIsCatalogClass()
+    {
         $this->assertInstanceOf(Catalog::class, $this->catalog);
     }
 
-    public function testGetGtinValueReturnsLabelForSelectAttribute()
+    public function testCronUploadFeedDoesNotTransmitEmptyBatchWhenNoProductsAreAdded()
     {
-        $product = $this->createMock(CatalogProduct::class);
-        $attribute = $this->getMockBuilder(AbstractAttribute::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['usesSource'])
-            ->getMock();
-        $attribute->method('usesSource')->willReturn(true);
-        $this->eavConfig->method('getAttribute')->willReturn($attribute);
-
-        $product->method('getAttributeText')
-            ->with('upc')
-            ->willReturn('UPC Label');
-
-        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
-        $this->assertSame('UPC Label', $this->catalog->getGtinValue($product, $gtinMap));
-    }
-
-    public function testGetGtinValueReturnsCommaSeparatedForMultiselect()
-    {
-        $product = $this->createMock(CatalogProduct::class);
-        $attribute = $this->getMockBuilder(AbstractAttribute::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['usesSource'])
-            ->getMock();
-        $attribute->method('usesSource')->willReturn(true);
-        $this->eavConfig->method('getAttribute')->willReturn($attribute);
-
-        $product->method('getAttributeText')
-            ->with('upc')
-            ->willReturn(['Red', 'Blue']);
-
-        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
-        $this->assertSame('Red, Blue', $this->catalog->getGtinValue($product, $gtinMap));
-    }
-
-    public function testGetGtinValueReturnsRawForNonSourceAttribute()
-    {
-        $product = $this->createMock(CatalogProduct::class);
-        $attribute = $this->getMockBuilder(AbstractAttribute::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['usesSource'])
-            ->getMock();
-        $attribute->method('usesSource')->willReturn(false);
-        $this->eavConfig->method('getAttribute')->willReturn($attribute);
-
-        $product->method('getData')
-            ->with('upc')
-            ->willReturn('12345');
-
-        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
-        $this->assertSame('12345', $this->catalog->getGtinValue($product, $gtinMap));
-    }
-
-    public function testGetGtinValueReturnsImplodedForArrayData()
-    {
-        $product = $this->createMock(CatalogProduct::class);
-        $attribute = $this->getMockBuilder(AbstractAttribute::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['usesSource'])
-            ->getMock();
-        $attribute->method('usesSource')->willReturn(false);
-        $this->eavConfig->method('getAttribute')->willReturn($attribute);
-
-        $product->method('getData')
-            ->with('upc')
-            ->willReturn([1, 2]);
-
-        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
-        $this->assertSame('1, 2', $this->catalog->getGtinValue($product, $gtinMap));
-    }
-
-    public function testAddProductToAtomFeedWritesConvertedFinalPriceWithCurrency()
-    {
-        $config = $this->createMock(ConfigModel::class);
-        $gtin = $this->createMock(Gtin::class);
-        $storeManager = $this->createMock(StoreManagerInterface::class);
-        $collectionFactory = $this->createMock(CollectionFactory::class);
-        $dateTimeFactory = $this->createMock(DateTimeFactory::class);
-        $imageHelper = $this->createMock(Image::class);
-        $turntoProduct = $this->createMock(Product::class);
-        $feedClient = $this->createMock(FeedClient::class);
-        $emulation = $this->createMock(Emulation::class);
-        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
-        $logger = $this->createMock(Monolog::class);
-
-        // Ensure safe SKU encoding passthrough
-        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
-            return (string) $value;
-        });
-
-        // Set expectations for currency conversion and currency code retrieval
         $storeId = 1;
-        $finalPrice = 12.34;
+        $store = $this->createStore($storeId);
 
-        $priceCurrency
-            ->expects($this->once())
-            ->method('convertAndRound')
-            ->with($finalPrice, $storeId)
-            ->willReturn($finalPrice);
+        $this->storeManager->method('getStores')->willReturn([$store]);
 
-        $currencyMock = $this->createPartialMock(
-            Currency::class,
-            ['getCurrencyCode']
+        $this->configValues[ConfigModel::PRODUCT_FEED_SUBMISSION_URL] = 'https://feed.test/upload';
+
+        $generator = $this->createMock(FeedGeneratorInterface::class);
+        $generator->expects($this->once())->method('getFeedStyle')->willReturn(FeedFormat::COMMERCE);
+        $isFeedOpen = false;
+        $generator->method('isFeedOpen')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                return $isFeedOpen;
+            }
         );
-        $currencyMock->method('getCurrencyCode')->willReturn('USD');
-        $priceCurrency->method('getCurrency')->with($storeId)->willReturn($currencyMock);
-
-        // Build the catalog instance under test
-        $catalog = new TestableCatalog(
-            $config,
-            $gtin,
-            $storeManager,
-            $collectionFactory,
-            $dateTimeFactory,
-            $imageHelper,
-            $turntoProduct,
-            $this->eavConfig,
-            $feedClient,
-            $emulation,
-            $priceCurrency,
-            $logger
+        $generator->expects($this->once())->method('beginFeed')->with($store)->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = true;
+                return null;
+            }
         );
+        $generator->expects($this->once())->method('addProduct')->willReturn(false);
+        $generator->expects($this->once())->method('finishFeed')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = false;
+                return 'feed';
+            }
+        );
+        $this->feedGeneratorFactory->method('create')->with(FeedFormat::COMMERCE)->willReturn($generator);
 
-        // Minimal product stub to satisfy feed requirements
         $product = $this->createMock(CatalogProduct::class);
-        $product->method('getSku')->willReturn('SKU-1');
-        $product->method('getProductUrl')->willReturn('https://example.com/p');
-        $product->method('getName')->willReturn('Product Name');
-        $product->method('getImage')->willReturn(null); // avoid image helper chain
-        $product->method('getFinalPrice')->willReturn($finalPrice);
-        $product->method('getCustomAttribute')->willReturn(null);
-        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+        $product->method('getId')->willReturn(1);
+        $product->method('getSku')->willReturn('SKU1');
+        $product->method('getTypeId')->willReturn('simple');
 
-        $entry = new SimpleXMLElement('<entry />');
+        $this->collectionFactory->method('create')->willReturn($this->createProductCollection([$product]));
 
-        // Execute
-        $catalog->callAddProductToAtomFeed($entry, $product, $storeId, false);
+        $this->exportProduct->expects($this->once())->method('preloadRewriteUrls')->with($storeId, [1]);
+        $this->categoryPathResolver->expects($this->once())->method('preloadCategoryPaths')->with($storeId, [1]);
+        $this->feedClient->expects($this->never())->method('transmitFeedFile');
+        $this->logger->expects($this->never())->method('error');
+        $this->emulation->expects($this->once())
+            ->method('startEnvironmentEmulation')
+            ->with($storeId, Area::AREA_FRONTEND, true);
+        $this->emulation->expects($this->once())->method('stopEnvironmentEmulation');
 
-        // Assert price element is present and formatted with currency code
-        $xmlString = $entry->asXML();
-        $this->assertIsString($xmlString);
-        $this->assertStringContainsString('<price>12.34 USD</price>', $xmlString);
+        $this->catalog = $this->createCatalog();
+        $this->catalog->cronUploadFeed();
+    }
+
+    public function testCronUploadFeedStartsFeedBeforeProcessingFirstProduct()
+    {
+        $storeId = 1;
+        $store = $this->createStore($storeId);
+
+        $this->storeManager->method('getStores')->willReturn([$store]);
+
+        $this->configValues[ConfigModel::PRODUCT_FEED_SUBMISSION_URL] = 'https://feed.test/upload';
+
+        $callOrder = [];
+
+        $generator = $this->createMock(FeedGeneratorInterface::class);
+        $generator->method('getFeedStyle')->willReturn(FeedFormat::COMMERCE);
+        $isFeedOpen = false;
+        $generator->method('isFeedOpen')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                return $isFeedOpen;
+            }
+        );
+        $generator->expects($this->once())->method('beginFeed')->with($store)->willReturnCallback(
+            function () use (&$callOrder, &$isFeedOpen) {
+                $isFeedOpen = true;
+                $callOrder[] = 'beginFeed';
+                return null;
+            }
+        );
+        $generator->expects($this->atLeastOnce())->method('addProduct')->willReturnCallback(
+            function () use (&$callOrder) {
+                $callOrder[] = 'addProduct';
+                return false;
+            }
+        );
+        $generator->expects($this->once())->method('finishFeed')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = false;
+                return 'feed';
+            }
+        );
+        $this->feedGeneratorFactory->method('create')->with(FeedFormat::COMMERCE)->willReturn($generator);
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getId')->willReturn(1);
+        $product->method('getSku')->willReturn('SKU1');
+        $product->method('getTypeId')->willReturn('simple');
+
+        $this->collectionFactory->method('create')->willReturn($this->createProductCollection([$product]));
+
+        $this->exportProduct->expects($this->once())->method('preloadRewriteUrls')->with($storeId, [1]);
+        $this->categoryPathResolver->expects($this->once())->method('preloadCategoryPaths')->with($storeId, [1]);
+        $this->feedClient->expects($this->never())->method('transmitFeedFile');
+        $this->logger->expects($this->never())->method('error');
+        $this->emulation->expects($this->once())
+            ->method('startEnvironmentEmulation')
+            ->with($storeId, Area::AREA_FRONTEND, true);
+        $this->emulation->expects($this->once())->method('stopEnvironmentEmulation');
+
+        $this->catalog = $this->createCatalog();
+        $this->catalog->cronUploadFeed();
+
+        $this->assertSame('beginFeed', $callOrder[0]);
+        $this->assertEquals('addProduct', $callOrder[1]);
+    }
+
+    public function testCronUploadFeedFinishesFeedWhenProductWriteFails()
+    {
+        $storeId = 1;
+        $store = $this->createStore($storeId);
+
+        $this->storeManager->method('getStores')->willReturn([$store]);
+
+        $this->configValues[ConfigModel::PRODUCT_FEED_SUBMISSION_URL] = 'https://feed.test/upload';
+
+        $generator = $this->createMock(FeedGeneratorInterface::class);
+        $generator->method('getFeedStyle')->willReturn(FeedFormat::COMMERCE);
+        $isFeedOpen = false;
+        $generator->method('isFeedOpen')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                return $isFeedOpen;
+            }
+        );
+        $generator->expects($this->once())->method('beginFeed')->with($store)->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = true;
+                return null;
+            }
+        );
+        $generator->expects($this->once())->method('addProduct')->willThrowException(new Exception('add failed'));
+        $generator->expects($this->once())->method('finishFeed')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = false;
+                return 'feed';
+            }
+        );
+        $this->feedGeneratorFactory->method('create')->with(FeedFormat::COMMERCE)->willReturn($generator);
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getId')->willReturn(1);
+        $product->method('getSku')->willReturn('SKU1');
+        $product->method('getTypeId')->willReturn('simple');
+
+        $this->collectionFactory->method('create')->willReturn($this->createProductCollection([$product]));
+
+        $this->exportProduct->expects($this->once())->method('preloadRewriteUrls')->with($storeId, [1]);
+        $this->categoryPathResolver->expects($this->once())->method('preloadCategoryPaths')->with($storeId, [1]);
+        $this->feedClient->expects($this->never())->method('transmitFeedFile');
+        $this->logger->expects($this->atLeastOnce())->method('error');
+        $this->emulation->expects($this->once())
+            ->method('startEnvironmentEmulation')
+            ->with($storeId, Area::AREA_FRONTEND, true);
+        $this->emulation->expects($this->once())->method('stopEnvironmentEmulation');
+
+        $this->catalog = $this->createCatalog();
+        $this->catalog->cronUploadFeed();
+    }
+
+    public function testCronUploadFeedLogsAndStopsWhenTransmitFails()
+    {
+        $storeId = 1;
+        $store = $this->createStore($storeId);
+
+        $this->storeManager->method('getStores')->willReturn([$store]);
+
+        $this->configValues[ConfigModel::PRODUCT_FEED_SUBMISSION_URL] = 'https://feed.test/upload';
+        $this->gtin->method('getGtinAttributesMap')->willReturn([]);
+
+        $generator = $this->createMock(FeedGeneratorInterface::class);
+        $generator->method('getFeedStyle')->willReturn(FeedFormat::COMMERCE);
+        $isFeedOpen = false;
+        $generator->method('isFeedOpen')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                return $isFeedOpen;
+            }
+        );
+        $generator->expects($this->once())->method('beginFeed')->with($store)->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = true;
+                return null;
+            }
+        );
+        $generator->expects($this->once())->method('addProduct')->willReturn(true);
+        $generator->expects($this->once())->method('finishFeed')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = false;
+                return 'feed';
+            }
+        );
+        $this->feedGeneratorFactory->method('create')->with(FeedFormat::COMMERCE)->willReturn($generator);
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getId')->willReturn(1);
+        $product->method('getSku')->willReturn('SKU1');
+        $product->method('getTypeId')->willReturn('simple');
+
+        $this->collectionFactory->method('create')->willReturn($this->createProductCollection([$product]));
+
+        $this->exportProduct->expects($this->once())->method('preloadRewriteUrls')->with($storeId, [1]);
+        $this->categoryPathResolver->expects($this->once())->method('preloadCategoryPaths')->with($storeId, [1]);
+        $this->feedClient->expects($this->once())
+            ->method('transmitFeedFile')
+            ->willThrowException(new Exception('transmit failed'));
+        $this->logger->expects($this->atLeastOnce())->method('error');
+        $this->emulation->expects($this->once())
+            ->method('startEnvironmentEmulation')
+            ->with($storeId, Area::AREA_FRONTEND, true);
+        $this->emulation->expects($this->once())->method('stopEnvironmentEmulation');
+
+        $this->catalog = $this->createCatalog();
+        $this->catalog->cronUploadFeed();
+    }
+
+    public function testGetProductsAddsDeterministicOrder()
+    {
+        $productCollection = $this->createProductCollection([], 3);
+        $productCollection->expects($this->once())->method('setOrder')->with('entity_id', 'ASC');
+        $this->collectionFactory->method('create')->willReturn($productCollection);
+
+        $this->catalog = $this->createCatalog();
+        $result = $this->catalog->getProducts(1, 1, 500);
+
+        $this->assertSame($productCollection, $result);
+    }
+
+    public function testGetProductsReturnsFalseWhenPageExceedsLastPage()
+    {
+        $productCollection = $this->createProductCollection([], 1);
+        $this->collectionFactory->method('create')->willReturn($productCollection);
+
+        $this->catalog = $this->createCatalog();
+        $result = $this->catalog->getProducts(1, 3, 500);
+
+        $this->assertFalse($result);
+    }
+
+    public function testCronUploadFeedSkipsStoreIfFeedFormatInvalid()
+    {
+        $storeId = 1;
+        $store = $this->createStore($storeId);
+
+        $this->storeManager->method('getStores')->willReturn([$store]);
+        $this->configValues[ConfigModel::PRODUCT_FEED_SUBMISSION_URL] = 'https://feed.test/upload';
+        $this->feedFormat = 'invalid_format';
+
+        $this->feedGeneratorFactory->expects($this->never())->method('create');
+        $this->collectionFactory->expects($this->never())->method('create');
+        $this->feedClient->expects($this->never())->method('transmitFeedFile');
+        $this->emulation->expects($this->never())->method('startEnvironmentEmulation');
+        $this->emulation->expects($this->never())->method('stopEnvironmentEmulation');
+        $this->logger->expects($this->once())->method('error');
+
+        $this->catalog->cronUploadFeed();
+    }
+
+    public function testCronUploadFeedSkipsStoreIfCredentialsIncomplete()
+    {
+        $storeId = 1;
+        $store = $this->createStore($storeId);
+
+        $this->storeManager->method('getStores')->willReturn([$store]);
+        $this->configValues[ConfigModel::PRODUCT_FEED_SUBMISSION_URL] = 'https://feed.test/upload';
+        $this->siteKey = '';
+
+        $this->feedGeneratorFactory->expects($this->never())->method('create');
+        $this->collectionFactory->expects($this->never())->method('create');
+        $this->feedClient->expects($this->never())->method('transmitFeedFile');
+        $this->logger->expects($this->once())->method('error');
+        $this->emulation->expects($this->never())->method('startEnvironmentEmulation');
+        $this->emulation->expects($this->never())->method('stopEnvironmentEmulation');
+
+        $this->catalog->cronUploadFeed();
+    }
+
+    public function testCronUploadFeedTransmitsFeedFileOnce()
+    {
+        $storeId = 1;
+        $store = $this->createStore($storeId);
+
+        $this->storeManager->method('getStores')->willReturn([$store]);
+        $this->configValues[ConfigModel::PRODUCT_FEED_SUBMISSION_URL] = 'https://feed.test/upload';
+
+        $generator = $this->createMock(FeedGeneratorInterface::class);
+        $generator->method('getFeedStyle')->willReturn(FeedFormat::COMMERCE);
+        $isFeedOpen = false;
+        $generator->method('isFeedOpen')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                return $isFeedOpen;
+            }
+        );
+        $generator->expects($this->once())->method('beginFeed')->with($store)->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = true;
+                return null;
+            }
+        );
+        $generator->expects($this->once())->method('addProduct')->willReturn(true);
+        $generator->method('finishFeed')->willReturnCallback(
+            function () use (&$isFeedOpen) {
+                $isFeedOpen = false;
+                return 'feed';
+            }
+        );
+        $this->feedGeneratorFactory->method('create')->with(FeedFormat::COMMERCE)->willReturn($generator);
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getId')->willReturn(1);
+        $product->method('getSku')->willReturn('SKU1');
+        $product->method('getTypeId')->willReturn('simple');
+
+        $this->collectionFactory->method('create')->willReturn($this->createProductCollection([$product]));
+
+        $this->exportProduct->expects($this->once())->method('preloadRewriteUrls')->with($storeId, [1]);
+        $this->categoryPathResolver->expects($this->once())->method('preloadCategoryPaths')->with($storeId, [1]);
+        $this->feedClient->expects($this->once())
+            ->method('transmitFeedFile')
+            ->willReturn(null);
+        $this->logger->expects($this->never())->method('error');
+
+        $this->catalog = $this->createCatalog();
+        $this->catalog->cronUploadFeed();
     }
 }

--- a/Test/Unit/Model/Export/CatalogTest.php
+++ b/Test/Unit/Model/Export/CatalogTest.php
@@ -124,6 +124,15 @@ class CatalogTest extends TestCase
                 return $this->configValues[$path] ?? null;
             }
         );
+        $this->config->method('getConfigBool')->willReturnCallback(
+            function ($path, $scopeCode = null) {
+                if (!array_key_exists($path, $this->configValues)) {
+                    return false;
+                }
+
+                return (bool) $this->configValues[$path];
+            }
+        );
         $this->config->method('getFeedFormat')->willReturnCallback(function ($storeId = null) {
             return $this->feedFormat;
         });

--- a/Test/Unit/Service/Feed/CommerceFeedGeneratorTest.php
+++ b/Test/Unit/Service/Feed/CommerceFeedGeneratorTest.php
@@ -1,0 +1,736 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Test\Unit\Service\Feed;
+
+use Magento\Catalog\Helper\Image;
+use Magento\Catalog\Model\Category;
+use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Bundle\Model\Product\Type as BundleType;
+use Magento\Catalog\Model\Product\Type\AbstractType;
+use Magento\GroupedProduct\Model\Product\Type\Grouped as GroupedType;
+use Magento\Directory\Model\Currency;
+use Magento\Eav\Model\Config as EavConfig;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Store\Model\Store;
+use PHPUnit\Framework\TestCase;
+use TurnTo\SocialCommerce\Model\Config as ConfigModel;
+use TurnTo\SocialCommerce\Model\Config\Gtin;
+use TurnTo\SocialCommerce\Model\Export\CategoryPathResolver;
+use TurnTo\SocialCommerce\Model\Export\Product as ExportProduct;
+use TurnTo\SocialCommerce\Model\Product;
+use TurnTo\SocialCommerce\Logger\Monolog;
+use TurnTo\SocialCommerce\Service\Feed\CommerceFeedGenerator;
+
+/**
+ * Exposes protected feed helpers for unit testing.
+ */
+class TestableCommerceFeedGenerator extends CommerceFeedGenerator
+{
+    /**
+     * @param ConfigModel $config
+     * @param Gtin $gtin
+     * @param Image $imageHelper
+     * @param Product $turntoProduct
+     * @param EavConfig $eavConfig
+     * @param PriceCurrencyInterface $priceCurrency
+     * @param Monolog $logger
+     * @param CategoryPathResolver $categoryPathResolver
+     * @param ExportProduct $exportProduct
+     */
+    public function __construct(
+        ConfigModel $config,
+        Gtin $gtin,
+        Image $imageHelper,
+        Product $turntoProduct,
+        EavConfig $eavConfig,
+        PriceCurrencyInterface $priceCurrency,
+        Monolog $logger,
+        CategoryPathResolver $categoryPathResolver,
+        ExportProduct $exportProduct
+    ) {
+        parent::__construct(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $categoryPathResolver,
+            $exportProduct
+        );
+    }
+
+    /**
+     * @param CatalogProduct $product
+     * @param int|string|null $storeId
+     * @param bool|CatalogProduct|null $parent
+     * @return string
+     */
+    public function callGenerateProductLine($product, $storeId, $parent)
+    {
+        return $this->generateProductLine($product, $storeId, $parent);
+    }
+
+    /**
+     * @param CatalogProduct $product
+     * @return string
+     */
+    public function callGetMembers($product)
+    {
+        return $this->getMembers($product);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getCategoryTreeString(CatalogProduct $product, $storeId)
+    {
+        return 'Category 1 > Category 2';
+    }
+
+    /**
+     * @param CatalogProduct $product
+     * @param int|string|null $storeId
+     * @return array
+     */
+    protected function getDeepestCategoryTree(CatalogProduct $product, $storeId)
+    {
+        return [
+            $this->getCategoryFixture('Category 1', 100),
+            $this->getCategoryFixture('Category 2', 200)
+        ];
+    }
+
+    /**
+     * @param string $name
+     * @param int $id
+     * @return Category
+     */
+    protected function getCategoryFixture(string $name, int $id)
+    {
+        $category = new class($name, $id) {
+            private string $name;
+            private int $id;
+
+            public function __construct(string $name, int $id)
+            {
+                $this->name = $name;
+                $this->id = $id;
+            }
+
+            public function getName(): string
+            {
+                return $this->name;
+            }
+
+            public function getId(): int
+            {
+                return $this->id;
+            }
+        };
+        return $category;
+    }
+}
+
+class CommerceFeedGeneratorTest extends TestCase
+{
+    /**
+     * @var TestableCommerceFeedGenerator
+     */
+    protected $generator;
+    /**
+     * @var CategoryPathResolver
+     */
+    protected $categoryPathResolver;
+
+    protected function setUp(): void
+    {
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $eavConfig = $this->createMock(EavConfig::class);
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $logger = $this->createMock(Monolog::class);
+
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return (string) $value;
+        });
+
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.test/p');
+        $this->categoryPathResolver = $this->createMock(CategoryPathResolver::class);
+
+        $this->generator = new TestableCommerceFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $this->categoryPathResolver,
+            $exportProduct
+        );
+    }
+
+    /**
+     * Mutates the feed stream property on the generator using native property scope binding.
+     *
+     * @param mixed $value
+     * @return void
+     */
+    private function setGeneratorStream($value): void
+    {
+        $setter = function ($value): void {
+            $this->stream = $value;
+        };
+        $setter = $setter->bindTo($this->generator, $this->generator::class);
+        $setter($value);
+    }
+
+    /**
+     * Reads the feed stream property on the generator using native property scope binding.
+     *
+     * @return mixed
+     */
+    private function getGeneratorStream()
+    {
+        $getter = function () {
+            return $this->stream;
+        };
+        $getter = $getter->bindTo($this->generator, $this->generator::class);
+        return $getter();
+    }
+
+    public function testGetMembersForBundleProduct()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getTypeId')->willReturn('bundle');
+
+        $typeInstance = $this->createMock(BundleType::class);
+        $typeInstance->method('getOptionsIds')->willReturn([1, 2]);
+
+        $selection1 = $this->createMock(CatalogProduct::class);
+        $selection1->method('getSku')->willReturn('CHILD-1');
+
+        $selection2 = $this->createMock(CatalogProduct::class);
+        $selection2->method('getSku')->willReturn('CHILD-2');
+
+        $typeInstance->method('getSelectionsCollection')->willReturn([$selection1, $selection2]);
+
+        $product->method('getTypeInstance')->willReturn($typeInstance);
+
+        $members = $this->generator->callGetMembers($product);
+        $this->assertEquals('CHILD-1,CHILD-2', $members);
+    }
+
+    public function testGetMembersForGroupedProduct()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getTypeId')->willReturn('grouped');
+
+        $typeInstance = $this->createMock(GroupedType::class);
+
+        $child1 = $this->createMock(CatalogProduct::class);
+        $child1->method('getSku')->willReturn('GROUP-CHILD-1');
+
+        $child2 = $this->createMock(CatalogProduct::class);
+        $child2->method('getSku')->willReturn('GROUP-CHILD-2');
+
+        $typeInstance->method('getAssociatedProducts')->willReturn([$child1, $child2]);
+
+        $product->method('getTypeInstance')->willReturn($typeInstance);
+
+        $members = $this->generator->callGetMembers($product);
+        $this->assertEquals('GROUP-CHILD-1,GROUP-CHILD-2', $members);
+    }
+
+    public function testGetMembersForBundleProductEncodesSpecialCharacterSku()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getTypeId')->willReturn('bundle');
+
+        $typeInstance = $this->createMock(BundleType::class);
+        $typeInstance->method('getOptionsIds')->willReturn([1, 2]);
+
+        $selection1 = $this->createMock(CatalogProduct::class);
+        $selection1->method('getSku')->willReturn('CHILD/1');
+
+        $selection2 = $this->createMock(CatalogProduct::class);
+        $selection2->method('getSku')->willReturn('CHILD+2');
+
+        $typeInstance->method('getSelectionsCollection')->willReturn([$selection1, $selection2]);
+
+        $product->method('getTypeInstance')->willReturn($typeInstance);
+
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return str_replace(
+                array_keys(Product::TURNTO_CHARACTER_MAPPING),
+                array_values(Product::TURNTO_CHARACTER_MAPPING),
+                (string) $value
+            );
+        });
+        $eavConfig = $this->createMock(EavConfig::class);
+        $logger = $this->createMock(Monolog::class);
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $exportProduct = $this->createMock(ExportProduct::class);
+
+        $generator = new TestableCommerceFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $this->categoryPathResolver,
+            $exportProduct
+        );
+
+        $members = $generator->callGetMembers($product);
+        $this->assertEquals('CHILDFORWARDSLASH1,CHILDPLUS2', $members);
+    }
+
+    public function testGetMembersForGroupedProductEncodesSpecialCharacterSku()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getTypeId')->willReturn('grouped');
+
+        $typeInstance = $this->createMock(GroupedType::class);
+
+        $child1 = $this->createMock(CatalogProduct::class);
+        $child1->method('getSku')->willReturn('GROUP/CHILD#1');
+
+        $child2 = $this->createMock(CatalogProduct::class);
+        $child2->method('getSku')->willReturn('GROUP/CHILD#2');
+
+        $typeInstance->method('getAssociatedProducts')->willReturn([$child1, $child2]);
+
+        $product->method('getTypeInstance')->willReturn($typeInstance);
+
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return str_replace(
+                array_keys(Product::TURNTO_CHARACTER_MAPPING),
+                array_values(Product::TURNTO_CHARACTER_MAPPING),
+                (string) $value
+            );
+        });
+        $eavConfig = $this->createMock(EavConfig::class);
+        $logger = $this->createMock(Monolog::class);
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $exportProduct = $this->createMock(ExportProduct::class);
+
+        $generator = new TestableCommerceFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $this->categoryPathResolver,
+            $exportProduct
+        );
+
+        $members = $generator->callGetMembers($product);
+        $this->assertEquals('GROUPFORWARDSLASHCHILDHASH1,GROUPFORWARDSLASHCHILDHASH2', $members);
+    }
+
+    public function testGenerateProductLine()
+    {
+        $storeId = 1;
+        $finalPrice = 12.34;
+
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $priceCurrency
+            ->method('convertAndRound')
+            ->with($finalPrice, $storeId)
+            ->willReturn($finalPrice);
+
+        $currencyMock = $this->createPartialMock(
+            Currency::class,
+            ['getCurrencyCode']
+        );
+        $currencyMock->method('getCurrencyCode')->willReturn('USD');
+        $priceCurrency->method('getCurrency')->with($storeId)->willReturn($currencyMock);
+
+        // Re-instantiate with mocked priceCurrency to test generateProductLine
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $eavConfig = $this->createMock(EavConfig::class);
+        $logger = $this->createMock(Monolog::class);
+
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return (string) $value;
+        });
+
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.com/p');
+
+        $generator = new TestableCommerceFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $this->categoryPathResolver,
+            $exportProduct
+        );
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('SKU-1');
+        $product->method('getName')->willReturn('Product Name');
+        $product->method('getImage')->willReturn(null);
+        $product->method('getFinalPrice')->willReturn($finalPrice);
+        $product->method('getCustomAttribute')->willReturn(null);
+        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+        $product->method('getTypeId')->willReturn('simple');
+
+        $line = $generator->callGenerateProductLine($product, $storeId, false);
+
+        $expectedCategoryJson = json_encode([
+            ['id' => '100', 'name' => 'Category 1'],
+            ['id' => '200', 'name' => 'Category 2']
+        ]);
+
+        $expectedLine = implode("\t", [
+            'SKU-1',
+            'Product Name',
+            'https://example.com/p',
+            '', // image_url
+            '0', // stock (not in stock / no qty when is_in_stock is false)
+            '1', // active
+            $expectedCategoryJson,
+            '', // virtual_parent_code
+            '', // members
+            '', // brand
+            'USD',
+            '12.34',
+            '', // upc
+            '', // ean
+            ''  // mpn
+        ]);
+
+        $this->assertEquals($expectedLine, $line);
+    }
+
+    public function testGenerateProductLineSkipsVirtualParentForSpecialCharacterSku()
+    {
+        $storeId = 1;
+        $finalPrice = 12.34;
+
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $priceCurrency
+            ->method('convertAndRound')
+            ->with($finalPrice, $storeId)
+            ->willReturn($finalPrice);
+
+        $currencyMock = $this->createPartialMock(
+            Currency::class,
+            ['getCurrencyCode']
+        );
+        $currencyMock->method('getCurrencyCode')->willReturn('USD');
+        $priceCurrency->method('getCurrency')->with($storeId)->willReturn($currencyMock);
+
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return str_replace(
+                array_keys(Product::TURNTO_CHARACTER_MAPPING),
+                array_values(Product::TURNTO_CHARACTER_MAPPING),
+                (string) $value
+            );
+        });
+        $eavConfig = $this->createMock(EavConfig::class);
+        $logger = $this->createMock(Monolog::class);
+
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.com/p');
+
+        $generator = new TestableCommerceFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $this->categoryPathResolver,
+            $exportProduct
+        );
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('SKU/1');
+        $product->method('getName')->willReturn('Product Name');
+        $product->method('getImage')->willReturn(null);
+        $product->method('getFinalPrice')->willReturn($finalPrice);
+        $product->method('getCustomAttribute')->willReturn(null);
+        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+        $product->method('getTypeId')->willReturn('simple');
+        $product->method('getData')->willReturnCallback(function ($value) {
+            if ($value === 'is_in_stock') {
+                return 1;
+            }
+            if ($value === 'qty') {
+                return 2;
+            }
+            return null;
+        });
+
+        $line = $generator->callGenerateProductLine($product, $storeId, false);
+
+        $expectedCategoryJson = json_encode([
+            ['id' => '100', 'name' => 'Category 1'],
+            ['id' => '200', 'name' => 'Category 2']
+        ]);
+
+        $expectedLine = implode("\t", [
+            'SKUFORWARDSLASH1',
+            'Product Name',
+            'https://example.com/p',
+            '', // image_url
+            '2', // stock (in stock)
+            '1', // active
+            $expectedCategoryJson,
+            '', // virtual_parent_code
+            '', // members
+            '', // brand
+            'USD',
+            '12.34',
+            '', // upc
+            '', // ean
+            ''  // mpn
+        ]);
+
+        $this->assertEquals($expectedLine, $line);
+    }
+
+    public function testGenerateProductLineEncodesVirtualParentFromParentSku()
+    {
+        $storeId = 1;
+        $finalPrice = 12.34;
+
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $priceCurrency
+            ->method('convertAndRound')
+            ->with($finalPrice, $storeId)
+            ->willReturn($finalPrice);
+
+        $currencyMock = $this->createPartialMock(
+            Currency::class,
+            ['getCurrencyCode']
+        );
+        $currencyMock->method('getCurrencyCode')->willReturn('USD');
+        $priceCurrency->method('getCurrency')->with($storeId)->willReturn($currencyMock);
+
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return str_replace(
+                array_keys(Product::TURNTO_CHARACTER_MAPPING),
+                array_values(Product::TURNTO_CHARACTER_MAPPING),
+                (string) $value
+            );
+        });
+        $eavConfig = $this->createMock(EavConfig::class);
+        $logger = $this->createMock(Monolog::class);
+
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.com/p');
+
+        $generator = new TestableCommerceFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $this->categoryPathResolver,
+            $exportProduct
+        );
+
+        $parent = $this->createMock(CatalogProduct::class);
+        $parent->method('getSku')->willReturn('PARENT/1');
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('CHILD+1');
+        $product->method('getName')->willReturn('Product Name');
+        $product->method('getImage')->willReturn(null);
+        $product->method('getFinalPrice')->willReturn($finalPrice);
+        $product->method('getCustomAttribute')->willReturn(null);
+        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+        $product->method('getTypeId')->willReturn('simple');
+        $product->method('getData')->willReturnCallback(function ($value) {
+            if ($value === 'is_in_stock') {
+                return 1;
+            }
+            if ($value === 'qty') {
+                return 2;
+            }
+            return null;
+        });
+
+        $line = $generator->callGenerateProductLine($product, $storeId, $parent);
+
+        $expectedCategoryJson = json_encode([
+            ['id' => '100', 'name' => 'Category 1'],
+            ['id' => '200', 'name' => 'Category 2']
+        ]);
+
+        $expectedLine = implode("\t", [
+            'CHILDPLUS1',
+            'Product Name',
+            'https://example.com/p',
+            '', // image_url
+            '2', // stock (in stock)
+            '1', // active
+            $expectedCategoryJson,
+            'PARENTFORWARDSLASH1', // virtual_parent_code
+            '', // members
+            '', // brand
+            'USD',
+            '12.34',
+            '', // upc
+            '', // ean
+            ''  // mpn
+        ]);
+
+        $this->assertEquals($expectedLine, $line);
+    }
+
+    public function testAddProductReturnsFalseIfProductCanNotBeAddedToFeed()
+    {
+        $storeId = 1;
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('');
+
+        $this->assertFalse($this->generator->addProduct($product, false, $storeId));
+    }
+
+    public function testAddProductReturnsTrueForValidProduct()
+    {
+        $storeId = 1;
+        $finalPrice = 12.34;
+
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $priceCurrency
+            ->method('convertAndRound')
+            ->with($finalPrice, $storeId)
+            ->willReturn($finalPrice);
+
+        $currencyMock = $this->createPartialMock(
+            Currency::class,
+            ['getCurrencyCode']
+        );
+        $currencyMock->method('getCurrencyCode')->willReturn('USD');
+        $priceCurrency->method('getCurrency')->with($storeId)->willReturn($currencyMock);
+
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return (string) $value;
+        });
+        $eavConfig = $this->createMock(EavConfig::class);
+        $logger = $this->createMock(Monolog::class);
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.com/p');
+
+        $generator = new TestableCommerceFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $eavConfig,
+            $priceCurrency,
+            $logger,
+            $this->categoryPathResolver,
+            $exportProduct
+        );
+
+        $store = $this->createMock(Store::class);
+        $store->method('getName')->willReturn('Test Store');
+        $store->method('getBaseUrl')->willReturn('https://example.test/');
+
+        $generator->beginFeed($store);
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('SKU-1');
+        $product->method('getName')->willReturn('Product Name');
+        $product->method('getImage')->willReturn(null);
+        $product->method('getFinalPrice')->willReturn($finalPrice);
+        $product->method('getCustomAttribute')->willReturn(null);
+        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+        $product->method('getTypeId')->willReturn('simple');
+        $product->method('getData')->willReturnCallback(function ($value) {
+            if ($value === 'is_in_stock') {
+                return 1;
+            }
+            if ($value === 'qty') {
+                return 2;
+            }
+            return null;
+        });
+
+        $result = $generator->addProduct($product, false, $storeId);
+
+        $this->assertTrue($result);
+    }
+
+    public function testFinishFeedThrowsWhenCalledWithoutBeginFeed()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Feed stream is not initialized. Call beginFeed() before finishFeed().');
+
+        $this->generator->finishFeed();
+    }
+
+    public function testFinishFeedCleansUpStateOnStreamError()
+    {
+        $store = $this->createMock(Store::class);
+        $store->method('getName')->willReturn('Test Store');
+        $store->method('getBaseUrl')->willReturn('https://example.test/');
+
+        $this->generator->beginFeed($store);
+        $this->assertTrue($this->generator->isFeedOpen());
+
+        $this->setGeneratorStream(null);
+
+        try {
+            $this->generator->finishFeed();
+            $this->fail('Expected finishFeed to throw an exception when stream resource is invalid');
+        } catch (\LogicException $e) {
+            $this->assertStringContainsString('Feed stream is invalid', $e->getMessage());
+        } finally {
+            $this->setGeneratorStream(null);
+            $this->assertFalse($this->generator->isFeedOpen());
+            $this->assertNull($this->getGeneratorStream());
+        }
+    }
+}

--- a/Test/Unit/Service/Feed/FeedGeneratorFactoryTest.php
+++ b/Test/Unit/Service/Feed/FeedGeneratorFactoryTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Test\Unit\Service\Feed;
+
+use PHPUnit\Framework\TestCase;
+use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
+use TurnTo\SocialCommerce\Service\Feed\CommerceFeedGenerator;
+use TurnTo\SocialCommerce\Service\Feed\FeedGeneratorFactory;
+use TurnTo\SocialCommerce\Service\Feed\GoogleFeedGenerator;
+
+class FeedGeneratorFactoryTest extends TestCase
+{
+    /**
+     * @var FeedGeneratorFactory
+     */
+    protected $factory;
+
+    /**
+     * @var GoogleFeedGenerator
+     */
+    protected $googleGenerator;
+
+    /**
+     * @var CommerceFeedGenerator
+     */
+    protected $commerceGenerator;
+
+    protected function setUp(): void
+    {
+        $this->googleGenerator = $this->createMock(GoogleFeedGenerator::class);
+        $this->commerceGenerator = $this->createMock(CommerceFeedGenerator::class);
+
+        $googleFactory = $this->createMock(\TurnTo\SocialCommerce\Service\Feed\GoogleFeedGeneratorFactory::class);
+        $googleFactory->method('create')->willReturn($this->googleGenerator);
+
+        $commerceFactory = $this->createMock(\TurnTo\SocialCommerce\Service\Feed\CommerceFeedGeneratorFactory::class);
+        $commerceFactory->method('create')->willReturn($this->commerceGenerator);
+
+        $generators = [
+            FeedFormat::GOOGLE_PRODUCT => $googleFactory,
+            FeedFormat::COMMERCE => $commerceFactory
+        ];
+
+        $this->factory = new FeedGeneratorFactory($generators);
+    }
+
+    public function testCreateGoogleFeedGenerator()
+    {
+        $result = $this->factory->create(FeedFormat::GOOGLE_PRODUCT);
+        $this->assertSame($this->googleGenerator, $result);
+    }
+
+    public function testCreateCommerceFeedGenerator()
+    {
+        $result = $this->factory->create(FeedFormat::COMMERCE);
+        $this->assertSame($this->commerceGenerator, $result);
+    }
+
+    public function testCreateThrowsExceptionForInvalidFormat()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid feed format: invalid_format');
+
+        $this->factory->create('invalid_format');
+    }
+}

--- a/Test/Unit/Service/Feed/GoogleFeedGeneratorTest.php
+++ b/Test/Unit/Service/Feed/GoogleFeedGeneratorTest.php
@@ -1,0 +1,446 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Test\Unit\Service\Feed;
+
+use Magento\Catalog\Helper\Image;
+use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Directory\Model\Currency;
+use Magento\Framework\Intl\DateTimeFactory;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
+use Magento\Eav\Model\Config as EavConfig;
+use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
+use Magento\Store\Model\Store;
+use PHPUnit\Framework\TestCase;
+use SimpleXMLElement;
+use TurnTo\SocialCommerce\Model\Config as ConfigModel;
+use TurnTo\SocialCommerce\Model\Config\Gtin;
+use TurnTo\SocialCommerce\Model\Export\CategoryPathResolver;
+use TurnTo\SocialCommerce\Model\Export\Product as ExportProduct;
+use TurnTo\SocialCommerce\Model\Product;
+use TurnTo\SocialCommerce\Logger\Monolog;
+use TurnTo\SocialCommerce\Service\Feed\GoogleFeedGenerator;
+
+/**
+ * Exposes protected feed helpers for unit testing.
+ */
+class TestableGoogleFeedGenerator extends GoogleFeedGenerator
+{
+    /**
+     * @param SimpleXMLElement $entry
+     * @param CatalogProduct $product
+     * @param int|string $storeId
+     * @param bool|CatalogProduct $parent
+     * @return void
+     */
+    public function callAddProductToAtomFeed($entry, $product, $storeId, $parent)
+    {
+        $this->addProductToAtomFeed($entry, $product, $storeId, $parent);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getCategoryTreeString(CatalogProduct $product, $storeId)
+    {
+        return '';
+    }
+}
+
+class GoogleFeedGeneratorTest extends TestCase
+{
+    /**
+     * @var TestableGoogleFeedGenerator
+     */
+    protected $generator;
+
+    /**
+     * @var EavConfig
+     */
+    protected $eavConfig;
+    /**
+     * @var CategoryPathResolver
+     */
+    protected $categoryPathResolver;
+
+    protected function setUp(): void
+    {
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $this->eavConfig = $this->createMock(EavConfig::class);
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $logger = $this->createMock(Monolog::class);
+        $dateTimeFactory = $this->createMock(DateTimeFactory::class);
+        $dateTime = $this->createMock(\DateTime::class);
+        $dateTime->method('format')->willReturn('2026-01-01T00:00:00+00:00');
+        $dateTimeFactory->method('create')->willReturn($dateTime);
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $this->categoryPathResolver = $this->createMock(CategoryPathResolver::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.test/p');
+
+        $this->generator = new TestableGoogleFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $this->eavConfig,
+            $priceCurrency,
+            $logger,
+            $dateTimeFactory,
+            $this->categoryPathResolver,
+            $exportProduct
+        );
+    }
+
+    /**
+     * Mutates the feed stream property on the generator using native property scope binding.
+     *
+     * @param mixed $value
+     * @return void
+     */
+    private function setGeneratorStream($value): void
+    {
+        $setter = function ($value): void {
+            $this->stream = $value;
+        };
+        $setter = $setter->bindTo($this->generator, $this->generator::class);
+        $setter($value);
+    }
+
+    /**
+     * Reads the feed stream property on the generator using native property scope binding.
+     *
+     * @return mixed
+     */
+    private function getGeneratorStream()
+    {
+        $getter = function () {
+            return $this->stream;
+        };
+        $getter = $getter->bindTo($this->generator, $this->generator::class);
+        return $getter();
+    }
+
+    public function testGetGtinValueReturnsLabelForSelectAttribute()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $attribute = $this->getMockBuilder(AbstractAttribute::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['usesSource'])
+            ->getMock();
+        $attribute->method('usesSource')->willReturn(true);
+        $this->eavConfig->method('getAttribute')->willReturn($attribute);
+
+        $product->method('getAttributeText')
+            ->with('upc')
+            ->willReturn('UPC Label');
+
+        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
+        $this->assertSame('UPC Label', $this->generator->getGtinValue($product, $gtinMap));
+    }
+
+    public function testGetGtinValueReturnsCommaSeparatedForMultiselect()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $attribute = $this->getMockBuilder(AbstractAttribute::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['usesSource'])
+            ->getMock();
+        $attribute->method('usesSource')->willReturn(true);
+        $this->eavConfig->method('getAttribute')->willReturn($attribute);
+
+        $product->method('getAttributeText')
+            ->with('upc')
+            ->willReturn(['Red', 'Blue']);
+
+        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
+        $this->assertSame('Red, Blue', $this->generator->getGtinValue($product, $gtinMap));
+    }
+
+    public function testGetGtinValueReturnsRawForNonSourceAttribute()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $attribute = $this->getMockBuilder(AbstractAttribute::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['usesSource'])
+            ->getMock();
+        $attribute->method('usesSource')->willReturn(false);
+        $this->eavConfig->method('getAttribute')->willReturn($attribute);
+
+        $product->method('getData')
+            ->with('upc')
+            ->willReturn('12345');
+
+        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
+        $this->assertSame('12345', $this->generator->getGtinValue($product, $gtinMap));
+    }
+
+    public function testGetGtinValueReturnsImplodedForArrayData()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $attribute = $this->getMockBuilder(AbstractAttribute::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['usesSource'])
+            ->getMock();
+        $attribute->method('usesSource')->willReturn(false);
+        $this->eavConfig->method('getAttribute')->willReturn($attribute);
+
+        $product->method('getData')
+            ->with('upc')
+            ->willReturn([1, 2]);
+
+        $gtinMap = [Gtin::UPC_ATTRIBUTE => 'upc'];
+        $this->assertSame('1, 2', $this->generator->getGtinValue($product, $gtinMap));
+    }
+
+    public function testAddProductToAtomFeedWritesConvertedFinalPriceWithCurrency()
+    {
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $logger = $this->createMock(Monolog::class);
+        $dateTimeFactory = $this->createMock(DateTimeFactory::class);
+
+        // Ensure safe SKU encoding passthrough
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return (string) $value;
+        });
+
+        // Set expectations for currency conversion and currency code retrieval
+        $storeId = 1;
+        $finalPrice = 12.34;
+
+        $priceCurrency
+            ->expects($this->once())
+            ->method('convertAndRound')
+            ->with($finalPrice, $storeId)
+            ->willReturn($finalPrice);
+
+        $currencyMock = $this->createPartialMock(
+            Currency::class,
+            ['getCurrencyCode']
+        );
+        $currencyMock->method('getCurrencyCode')->willReturn('USD');
+        $priceCurrency->method('getCurrency')->with($storeId)->willReturn($currencyMock);
+
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.com/p');
+
+        $generator = new TestableGoogleFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $this->eavConfig,
+            $priceCurrency,
+            $logger,
+            $dateTimeFactory,
+            $this->categoryPathResolver,
+            $exportProduct
+        );
+
+        // Minimal product stub to satisfy feed requirements
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('SKU-1');
+        $product->method('getName')->willReturn('Product Name');
+        $product->method('getImage')->willReturn(null); // avoid image helper chain
+        $product->method('getFinalPrice')->willReturn($finalPrice);
+        $product->method('getCustomAttribute')->willReturn(null);
+        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+
+        $entry = new SimpleXMLElement('<entry />');
+
+        // Execute
+        $generator->callAddProductToAtomFeed($entry, $product, $storeId, false);
+
+        // Assert price element is present and formatted with currency code
+        $xmlString = $entry->asXML();
+        $this->assertIsString($xmlString);
+        $this->assertStringContainsString(
+            '<g:price xmlns:g="http://base.google.com/ns/1.0">12.34 USD</g:price>',
+            $xmlString
+        );
+    }
+
+    public function testAddProductToAtomFeedWritesEncodedItemGroupIdFromParent()
+    {
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $logger = $this->createMock(Monolog::class);
+        $dateTimeFactory = $this->createMock(DateTimeFactory::class);
+
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return str_replace(
+                array_keys(Product::TURNTO_CHARACTER_MAPPING),
+                array_values(Product::TURNTO_CHARACTER_MAPPING),
+                (string) $value
+            );
+        });
+
+        $priceCurrency
+            ->expects($this->once())
+            ->method('convertAndRound')
+            ->with(12.34, 1)
+            ->willReturn(12.34);
+
+        $currencyMock = $this->createPartialMock(
+            Currency::class,
+            ['getCurrencyCode']
+        );
+        $currencyMock->method('getCurrencyCode')->willReturn('USD');
+        $priceCurrency->method('getCurrency')->with(1)->willReturn($currencyMock);
+
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.com/p');
+
+        $generator = new TestableGoogleFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $this->eavConfig,
+            $priceCurrency,
+            $logger,
+            $dateTimeFactory,
+            $this->categoryPathResolver,
+            $exportProduct
+        );
+
+        $parent = $this->createMock(CatalogProduct::class);
+        $parent->method('getSku')->willReturn('PARENT/1');
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('CHILD+1');
+        $product->method('getName')->willReturn('Product Name');
+        $product->method('getImage')->willReturn(null);
+        $product->method('getFinalPrice')->willReturn(12.34);
+        $product->method('getCustomAttribute')->willReturn(null);
+        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+
+        $entry = new SimpleXMLElement('<entry />');
+        $generator->callAddProductToAtomFeed($entry, $product, 1, $parent);
+
+        $xmlString = $entry->asXML();
+        $this->assertStringContainsString(
+            '<g:item_group_id xmlns:g="http://base.google.com/ns/1.0">PARENTFORWARDSLASH1</g:item_group_id>',
+            $xmlString
+        );
+    }
+
+    public function testAddProductReturnsFalseIfProductCanNotBeAdded()
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('');
+
+        $this->assertFalse($this->generator->addProduct($product, false, 1));
+    }
+
+    public function testAddProductReturnsTrueForValidProduct()
+    {
+        $storeId = 1;
+        $finalPrice = 12.34;
+
+        $config = $this->createMock(ConfigModel::class);
+        $gtin = $this->createMock(Gtin::class);
+        $imageHelper = $this->createMock(Image::class);
+        $turntoProduct = $this->createMock(Product::class);
+        $turntoProduct->method('turnToSafeEncoding')->willReturnCallback(function ($value) {
+            return (string) $value;
+        });
+        $priceCurrency = $this->createMock(PriceCurrencyInterface::class);
+        $logger = $this->createMock(Monolog::class);
+        $dateTimeFactory = $this->createMock(DateTimeFactory::class);
+        $dateTime = $this->createMock(\DateTime::class);
+        $dateTime->method('format')->willReturn('2026-01-01T00:00:00+00:00');
+        $dateTimeFactory->method('create')->willReturn($dateTime);
+
+        $priceCurrency
+            ->method('convertAndRound')
+            ->with($finalPrice, $storeId)
+            ->willReturn($finalPrice);
+
+        $currencyMock = $this->createPartialMock(
+            Currency::class,
+            ['getCurrencyCode']
+        );
+        $currencyMock->method('getCurrencyCode')->willReturn('USD');
+        $priceCurrency->method('getCurrency')->with($storeId)->willReturn($currencyMock);
+
+        $exportProduct = $this->createMock(ExportProduct::class);
+        $exportProduct->method('getProductUrl')->willReturn('https://example.com/p');
+
+        $generator = new TestableGoogleFeedGenerator(
+            $config,
+            $gtin,
+            $imageHelper,
+            $turntoProduct,
+            $this->eavConfig,
+            $priceCurrency,
+            $logger,
+            $dateTimeFactory,
+            $this->categoryPathResolver,
+            $exportProduct
+        );
+
+        $store = $this->createMock(Store::class);
+        $store->method('getName')->willReturn('Test Store');
+        $store->method('getBaseUrl')->willReturn('https://example.test/');
+
+        $generator->beginFeed($store);
+
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getSku')->willReturn('SKU-1');
+        $product->method('getName')->willReturn('Product Name');
+        $product->method('getImage')->willReturn(null);
+        $product->method('getFinalPrice')->willReturn($finalPrice);
+        $product->method('getCustomAttribute')->willReturn(null);
+        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+
+        $result = $generator->addProduct($product, false, $storeId);
+
+        $this->assertTrue($result);
+    }
+
+    public function testFinishFeedThrowsWhenCalledWithoutBeginFeed()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Feed stream is not initialized. Call beginFeed() before finishFeed().');
+
+        $this->generator->finishFeed();
+    }
+
+    public function testFinishFeedCleansUpStateOnStreamError()
+    {
+        $store = $this->createMock(Store::class);
+        $store->method('getName')->willReturn('Test Store');
+        $store->method('getBaseUrl')->willReturn('https://example.test/');
+
+        $this->generator->beginFeed($store);
+        $this->assertTrue($this->generator->isFeedOpen());
+
+        $this->setGeneratorStream(null);
+
+        try {
+            $this->generator->finishFeed();
+            $this->fail('Expected finishFeed to throw an exception when stream resource is invalid');
+        } catch (\LogicException $e) {
+            $this->assertStringContainsString('Feed stream is invalid', $e->getMessage());
+        } finally {
+            $this->setGeneratorStream(null);
+            $this->assertFalse($this->generator->isFeedOpen());
+            $this->assertNull($this->getGeneratorStream());
+        }
+    }
+}

--- a/Test/Unit/Service/GoogleFeed/ClientTest.php
+++ b/Test/Unit/Service/GoogleFeed/ClientTest.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace TurnTo\SocialCommerce\Test\Unit\Service\GoogleFeed;
+
+use Exception;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\TransferException;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use TurnTo\SocialCommerce\Logger\Monolog;
+use TurnTo\SocialCommerce\Model\Config;
+use TurnTo\SocialCommerce\Model\Config\Source\FeedFormat;
+use TurnTo\SocialCommerce\Model\File;
+use TurnTo\SocialCommerce\Service\GoogleFeed\Client;
+
+class TestableClient extends Client
+{
+    protected function getRetryDelayMicroseconds(int $attempt): int
+    {
+        return 0;
+    }
+}
+
+class ClientTest extends TestCase
+{
+    /**
+     * @var Config
+     */
+    protected $config;
+    /**
+     * @var GuzzleClient
+     */
+    protected $client;
+    /**
+     * @var File
+     */
+    protected $file;
+    /**
+     * @var Monolog
+     */
+    protected $logger;
+
+    protected function setUp(): void
+    {
+        $this->config = $this->createMock(Config::class);
+        $this->client = $this->createMock(GuzzleClient::class);
+        $this->file = $this->createMock(File::class);
+        $this->logger = $this->createMock(Monolog::class);
+
+        $this->config->method('getConfigValue')->willReturn('https://feed.test/upload');
+        $this->config->method('getSiteKey')->willReturn('site-key');
+        $this->config->method('getAuthorizationKey')->willReturn('auth-key');
+    }
+
+    public function testTransmitFeedFileSuccessWritesRequestAndReturns()
+    {
+        $response = $this->createResponse(200, 'SUCCESS');
+        $writeCalls = [];
+        $this->client->expects($this->once())
+            ->method('request')
+            ->willReturn($response);
+
+        $this->file->expects($this->exactly(2))
+            ->method('writeFile')
+            ->willReturnCallback(function ($fileName, $contents) use (&$writeCalls) {
+                $writeCalls[] = [$fileName, $contents];
+            });
+        $this->logger->expects($this->never())->method('warning');
+        $this->logger->expects($this->never())->method('error');
+
+        $client = new TestableClient(
+            $this->config,
+            $this->logger,
+            $this->client,
+            $this->file
+        );
+        $client->transmitFeedFile(
+            'feed-content',
+            'catalog.tsv',
+            FeedFormat::COMMERCE,
+            'default'
+        );
+
+        $this->assertSame(
+            [
+                ['turnto/commerce-product_storecode_default.tsv', 'feed-content'],
+                ['turnto/commerce-product_storecode_default_request.txt', 'SUCCESS']
+            ],
+            $writeCalls
+        );
+    }
+
+    public function testTransmitFeedFileRetriesOnServerErrorBeforeSuccess()
+    {
+        $serverError = $this->createResponse(500, 'Server unavailable');
+        $success = $this->createResponse(200, 'SUCCESS');
+        $this->client->expects($this->exactly(2))
+            ->method('request')
+            ->willReturnOnConsecutiveCalls($serverError, $success);
+
+        $this->logger->expects($this->once())->method('warning');
+        $this->logger->expects($this->never())->method('error');
+
+        $this->file->expects($this->any())->method('writeFile');
+
+        $client = new TestableClient(
+            $this->config,
+            $this->logger,
+            $this->client,
+            $this->file
+        );
+        $client->transmitFeedFile(
+            'feed-content',
+            'catalog.tsv',
+            FeedFormat::COMMERCE,
+            'default'
+        );
+    }
+
+    public function testTransmitFeedFileRetriesOnTooManyRequestsBeforeSuccess()
+    {
+        $rateLimitResponse = $this->createResponse(429, 'Too Many Requests');
+        $success = $this->createResponse(200, 'SUCCESS');
+        $this->client->expects($this->exactly(2))
+            ->method('request')
+            ->willReturnOnConsecutiveCalls($rateLimitResponse, $success);
+
+        $this->logger->expects($this->once())->method('warning');
+        $this->logger->expects($this->never())->method('error');
+
+        $this->file->expects($this->any())->method('writeFile');
+
+        $client = new TestableClient(
+            $this->config,
+            $this->logger,
+            $this->client,
+            $this->file
+        );
+        $client->transmitFeedFile(
+            'feed-content',
+            'catalog.tsv',
+            FeedFormat::COMMERCE,
+            'default'
+        );
+    }
+
+    public function testTransmitFeedFileDoesNotRetryForPermaErrorResponse()
+    {
+        $this->client->expects($this->once())
+            ->method('request')
+            ->willReturn($this->createResponse(400, 'Invalid request'));
+
+        $this->logger->expects($this->never())->method('warning');
+        $this->logger->expects($this->once())->method('error');
+
+        $this->expectException(Exception::class);
+
+        $client = new TestableClient(
+            $this->config,
+            $this->logger,
+            $this->client,
+            $this->file
+        );
+        $client->transmitFeedFile(
+            'feed-content',
+            'catalog.tsv',
+            FeedFormat::COMMERCE,
+            'default'
+        );
+    }
+
+    public function testTransmitFeedFileDoesNotRetryForErrorPayload()
+    {
+        $this->client->expects($this->once())
+            ->method('request')
+            ->willReturn($this->createResponse(200, 'Validation failed'));
+
+        $this->logger->expects($this->never())->method('warning');
+        $this->logger->expects($this->once())->method('error');
+
+        $this->expectException(Exception::class);
+
+        $client = new TestableClient(
+            $this->config,
+            $this->logger,
+            $this->client,
+            $this->file
+        );
+        $client->transmitFeedFile(
+            'feed-content',
+            'catalog.tsv',
+            FeedFormat::COMMERCE,
+            'default'
+        );
+    }
+
+    public function testTransmitFeedFileRetriesNetworkErrorUntilMaxAttempts()
+    {
+        $this->client->expects($this->exactly(3))
+            ->method('request')
+            ->willThrowException(new TransferException('network failure'));
+
+        $this->logger->expects($this->exactly(2))->method('warning');
+        $this->logger->expects($this->once())->method('error');
+
+        $this->expectException(TransferException::class);
+
+        $client = new TestableClient(
+            $this->config,
+            $this->logger,
+            $this->client,
+            $this->file
+        );
+        $client->transmitFeedFile(
+            'feed-content',
+            'catalog.tsv',
+            FeedFormat::COMMERCE,
+            'default'
+        );
+    }
+
+    protected function createResponse(int $statusCode, string $body): ResponseInterface
+    {
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('getContents')->willReturn($body);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn($statusCode);
+        $response->method('getBody')->willReturn($stream);
+
+        return $response;
+    }
+}

--- a/ViewModel/ConfigJs.php
+++ b/ViewModel/ConfigJs.php
@@ -7,9 +7,11 @@ declare(strict_types=1);
 
 namespace TurnTo\SocialCommerce\ViewModel;
 
+use Magento\Catalog\Model\Locator\RegistryLocator;
 use Magento\Catalog\Model\Product;
-use Magento\Framework\Registry;
+use Magento\Framework\Exception\NotFoundException;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
+use TurnTo\SocialCommerce\Logger\Monolog;
 use TurnTo\SocialCommerce\Model\Product as ProductModel;
 use TurnTo\SocialCommerce\Model\Config as ConfigModel;
 
@@ -28,23 +30,30 @@ class ConfigJs implements ArgumentInterface
      */
     protected $productModel;
     /**
-     * @var Registry
+     * @var RegistryLocator
      */
-    protected $registry;
+    protected $locator;
+    /**
+     * @var Monolog
+     */
+    protected $logger;
 
     /**
      * @param ConfigModel $config
      * @param ProductModel $productModel
-     * @param Registry $registry
+     * @param RegistryLocator $locator
+     * @param Monolog $logger
      */
     public function __construct(
         ConfigModel $config,
         ProductModel $productModel,
-        Registry $registry
+        RegistryLocator $locator,
+        Monolog $logger
     ) {
         $this->config = $config;
         $this->productModel = $productModel;
-        $this->registry = $registry;
+        $this->locator = $locator;
+        $this->logger = $logger;
     }
 
     /**
@@ -69,11 +78,13 @@ class ConfigJs implements ArgumentInterface
 
     protected function getProduct()
     {
-        if (is_null($this->product)) {
-            $this->product = $this->registry->registry('product');
-
-            if (!$this->product->getId()) {
-                return null;
+        if ($this->product === null) {
+            try {
+                $product = $this->locator->getProduct();
+                $this->product = ($product && $product->getId()) ? $product : null;
+            } catch (NotFoundException $e) {
+                $this->logger->error($e->getMessage(), ['exception' => $e]);
+                $this->product = null;
             }
         }
 

--- a/ViewModel/JSOrderFeed.php
+++ b/ViewModel/JSOrderFeed.php
@@ -14,6 +14,7 @@ use Magento\Sales\Model\Order\Item;
 use TurnTo\SocialCommerce\Model\Config;
 use TurnTo\SocialCommerce\Model\Product;
 use TurnTo\SocialCommerce\Model\Config\Source\AddressFallback;
+use TurnTo\SocialCommerce\Logger\Monolog;
 
 class JSOrderFeed implements ArgumentInterface
 {
@@ -36,23 +37,30 @@ class JSOrderFeed implements ArgumentInterface
      * @var Product
      */
     protected $product;
+    /**
+     * @var Monolog
+     */
+    protected $logger;
 
     /**
      * @param Config $config
      * @param Session $checkoutSession
      * @param Image $imageHelper
      * @param Product $product
+     * @param Monolog $logger
      */
     public function __construct(
         Config $config,
         Session $checkoutSession,
         Image   $imageHelper,
-        Product $product
+        Product $product,
+        Monolog $logger
     ) {
         $this->config = $config;
         $this->checkoutSession = $checkoutSession;
         $this->imageHelper = $imageHelper;
         $this->product = $product;
+        $this->logger = $logger;
     }
 
     /**
@@ -62,6 +70,24 @@ class JSOrderFeed implements ArgumentInterface
     {
         // Get the customer's first and last name from their account if possible
         $order = $this->checkoutSession->getLastRealOrder();
+        if (!$order || !$order->getEntityId()) {
+            $this->logger->error(
+                'Cannot render TurnTo order feed data because last real order is missing.',
+                [
+                    'last_real_order_id' => $this->checkoutSession->getLastRealOrderId(),
+                    'quote_id' => $this->checkoutSession->getQuoteId(),
+                ]
+            );
+            return json_encode(
+                [
+                    'error' => true,
+                    'errorCode' => 'order_not_found',
+                    'errorMessage' => 'No last real order available for order confirmation page.'
+                ],
+                JSON_PRETTY_PRINT
+            );
+        }
+
         $storeId = $order->getStoreId();
         $firstName = $order->getCustomerFirstname();
         $lastName = $order->getCustomerLastname();
@@ -82,8 +108,10 @@ class JSOrderFeed implements ArgumentInterface
                 }
             }
 
-            $firstName = $address->getFirstname();
-            $lastName = $address->getLastname();
+            if ($address) {
+                $firstName = $address->getFirstname();
+                $lastName = $address->getLastname();
+            }
         }
 
         $orderItems = [];

--- a/ViewModel/Widget.php
+++ b/ViewModel/Widget.php
@@ -72,6 +72,21 @@ class Widget implements ArgumentInterface
     }
 
     /**
+     * @return string|null
+     */
+    public function getWidgetUrl()
+    {
+        $baseUrl = $this->config->getConfigValue(ConfigModel::PRODUCT_WIDGET_URL);
+        $siteKey = $this->config->getSiteKey();
+
+        if (!$baseUrl || !$siteKey) {
+            return null;
+        }
+
+        return rtrim($baseUrl, '/') . '/' . ConfigModel::SOCIALCOMMERCE_VERSION . '/widgets/' . $siteKey . '/js/turnto.js';
+    }
+
+    /**
      * @return string
      */
     public function getAuthorizationKey()

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         }
     ],
     "require": {
+        "ext-simplexml": "*",
         "magento/framework": "102.0.*||103.0.*",
         "magento/module-backend": "101.0.*||102.0.*",
         "magento/module-catalog": "103.0.*||104.0.*",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "turnto/social-commerce",
     "description": "Social commerce platform to collect, manage, and display ratings and reviews to enhance your Magento store",
-    "version": "3.8.8",
+    "version": "3.9.0",
     "type": "magento2-module",
     "license": [
         "OSL-3.0"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -210,6 +210,15 @@
                         <field id="turnto_socialcommerce_configuration/general/enabled">1</field>
                     </depends>
                 </field>
+                <field id="feed_format" translate="label comment" type="select" sortOrder="15" showInStore="1" showInWebsite="1" showInDefault="1">
+                    <label>Feed Format</label>
+                    <comment><![CDATA[Recommend commerce feed for new installs. Should not be changed, without contacting your Emplifi customer success team.]]></comment>
+                    <source_model>TurnTo\SocialCommerce\Model\Config\Source\FeedFormat</source_model>
+                    <depends>
+                        <field id="enable_automatic_submission">1</field>
+                        <field id="turnto_socialcommerce_configuration/general/enabled">1</field>
+                    </depends>
+                </field>
                 <field id="product_feed_url" translate="label comment" type="text" sortOrder="20" showInStore="1" showInWebsite="1" showInDefault="1">
                     <label>Product Ratings Feed URL</label>
                     <comment><![CDATA[The URL from which to retrieve the Emplifi SKU Average Rating Feed.<br>Default: <b>https://export.turnto.com/</b>]]></comment>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -154,7 +154,7 @@
                     </depends>
                 </field>
                 <field id="enable_comments_pdp" translate="label comment" type="select" sortOrder="20" showInDefault="1" showInStore="1" showInWebsite="1">
-                    <label>Enable Display Widget on Product Page</label>
+                    <label>Enable Comments Display</label>
                     <comment><![CDATA[
                         Enable viewing checkout comments on the product details page.
                     ]]></comment>
@@ -164,7 +164,7 @@
                     </depends>
                 </field>
                 <field id="enable_top_comments" translate="label comment" type="select" sortOrder="30" showInDefault="1" showInStore="1" showInWebsite="1">
-                    <label>Enable Top Comments</label>
+                    <label>Enable Top Comments Display</label>
                     <comment><![CDATA[
                         Enable top comments block on the product details page
                     ]]></comment>
@@ -174,7 +174,7 @@
                     </depends>
                 </field>
                 <field id="enable_comments_pinboard_teaser" translate="label comment" type="select" sortOrder="30" showInDefault="1" showInStore="1" showInWebsite="1">
-                    <label>Enable Top Comments</label>
+                    <label>Enable Comments Pinboard Teaser</label>
                     <comment><![CDATA[
                         Enable comments pinboard teaser block on the product details page
                     ]]></comment>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -46,6 +46,7 @@
             </gallery>
             <product_feed>
                 <enable_automatic_submission>1</enable_automatic_submission>
+                <feed_format>google-product.xml</feed_format>
                 <product_feed_url>https://export.turnto.com/</product_feed_url>
                 <feed_submission_url>https://www.turnto.com/feedUpload/postfile</feed_submission_url>
                 <review_api_url>https://cdn-ws.turnto.com/v5/sitedata/</review_api_url>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 /**
- * Copyright © Pixlee TurnTo, Inc. All rights reserved.
+ * Copyright © Emplifi, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 -->
@@ -22,14 +22,8 @@
                 <jan_attribute/>
                 <asin_attribute/>
             </product_attribute_mappings>
-            <checkout_comments>
-                <enable_checkout_success>1</enable_checkout_success>
-                <enable_product_detail>1</enable_product_detail>
-                <columns>1</columns>
-            </checkout_comments>
             <qa>
                 <enable_qa>1</enable_qa>
-                <setup_type>dynamicEmbed</setup_type>
             </qa>
             <teaser>
                 <use_local_teaser_code>0</use_local_teaser_code>
@@ -39,11 +33,7 @@
             </teaser>
             <reviews>
                 <enable_reviews>1</enable_reviews>
-                <reviews_setup_type>dynamicEmbed</reviews_setup_type>
             </reviews>
-            <gallery>
-                <enable_gallery>1</enable_gallery>
-            </gallery>
             <product_feed>
                 <enable_automatic_submission>1</enable_automatic_submission>
                 <feed_format>google-product.xml</feed_format>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -21,6 +21,14 @@
             </argument>
         </arguments>
     </type>
+    <type name="TurnTo\SocialCommerce\Service\Feed\FeedGeneratorFactory">
+        <arguments>
+            <argument name="generators" xsi:type="array">
+                <item name="google-product.xml" xsi:type="object">TurnTo\SocialCommerce\Service\Feed\GoogleFeedGeneratorFactory</item>
+                <item name="tab-style.commerce" xsi:type="object">TurnTo\SocialCommerce\Service\Feed\CommerceFeedGeneratorFactory</item>
+            </argument>
+        </arguments>
+    </type>
     <type name="Magento\Catalog\Block\Product\View\Description">
         <plugin name="removeQuestionsTab" type="TurnTo\SocialCommerce\Plugin\Catalog\Block\Product\View\Description" />
     </type>

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -16,6 +16,7 @@
                         <item name="pageId" xsi:type="string">pdp-page</item>
                         <item name="chatter" xsi:type="array"/>
                     </argument>
+                    <argument name="view_model" xsi:type="object">TurnTo\SocialCommerce\ViewModel\Widget</argument>
                 </arguments>
             </block>
             <block name="turnto.pdp" template="TurnTo_SocialCommerce::product/view/config.phtml">
@@ -56,7 +57,7 @@
 
         <!-- Top Comments PDP Content -->
         <referenceContainer name="content">
-            <block name="turnto_checkout_comments" template="TurnTo_SocialCommerce::product/view/comments.phtml" after="product.info.details" ifconfig="turnto_socialcommerce_configuration/checkout_comments/enable_product_detail">
+            <block name="turnto_checkout_comments" template="TurnTo_SocialCommerce::product/view/comments.phtml" after="product.info.details" ifconfig="turnto_socialcommerce_configuration/checkout_comments/enable_top_comments">
                 <arguments>
                     <argument name="view_model" xsi:type="object">TurnTo\SocialCommerce\ViewModel\Widget</argument>
                 </arguments>

--- a/view/frontend/templates/onepage/js_order_feed.phtml
+++ b/view/frontend/templates/onepage/js_order_feed.phtml
@@ -15,5 +15,10 @@ $viewModel = $block->getViewModel();
 ?>
 
 <script type="text/javascript">
-    TurnToCmd('feed.send', <?= $viewModel->getFeedPurchaseOrderData() ?>);
+    let turnToOrderFeedData = <?= $viewModel->getFeedPurchaseOrderData() ?>;
+    if (!turnToOrderFeedData || turnToOrderFeedData.error) {
+        console.error('TurnTo order feed payload invalid or unavailable.', turnToOrderFeedData);
+    } else {
+        TurnToCmd('feed.send', turnToOrderFeedData);
+    }
 </script>

--- a/view/frontend/templates/product/view/reviews-tab.phtml
+++ b/view/frontend/templates/product/view/reviews-tab.phtml
@@ -26,10 +26,9 @@ $viewModel = $block->getViewModel();
                             "component": "TurnTo_SocialCommerce/js/reviews-tab",
                             "config": {
                                 "siteKey": "<?= $viewModel->getSiteKey() ?>",
-                                "reviewSku": "<?= $viewModel->turnToSafeEncoding($viewModel->getProductSku()) ?>",
+                                "reviewSku": "<?= $viewModel->getProductSku() ?>",
                                 "reviewsEnabled": "<?= $viewModel->getConfigBool(Config::REVIEWS_ENABLE) ? 'true' : 'false' ?>",
                                 "reviewsUrl": "<?= $viewModel->getConfigValue(Config::PRODUCT_REVIEW_URL) ?>"
-
                             }
                         }
                     }

--- a/view/frontend/templates/product/view/teaser-conditional.phtml
+++ b/view/frontend/templates/product/view/teaser-conditional.phtml
@@ -27,7 +27,7 @@ $viewModel = $block->getViewModel();
                                 "component": "TurnTo_SocialCommerce/js/teaser",
                                 "config": {
                                     "siteKey": "<?= $viewModel->getSiteKey() ?>",
-                                    "teaserSku": "<?= $viewModel->turnToSafeEncoding($block->getProduct()->getSku()) ?>",
+                                    "teaserSku": "<?= $viewModel->getProductSku() ?>",
                                     "reviewsEnabled": "<?= $viewModel->getConfigBool(Config::REVIEWS_ENABLE) ? 'true' : 'false' ?>",
                                     "reviewsTeaserEnabled": "<?= $viewModel->getConfigBool(Config::TEASER_REVIEWS_TEASER_ENABLE) ? 'true' : 'false' ?>",
                                     "qaEnabled": "<?= $viewModel->getConfigBool(Config::QA_ENABLE) ? 'true' : 'false' ?>",

--- a/view/frontend/templates/turnto-config.phtml
+++ b/view/frontend/templates/turnto-config.phtml
@@ -5,12 +5,19 @@
  */
 
 use TurnTo\SocialCommerce\Block\TurnToConfig;
-use TurnTo\SocialCommerce\Model\Config;
+use TurnTo\SocialCommerce\ViewModel\Widget;
 
 /**
  * @var TurnToConfig $block
+ * @var Widget $viewModel
  */
-$siteKey = $block->getSiteKey();
+$viewModel = $block->getViewModel();
+$widgetUrl = $viewModel->getWidgetUrl();
+
+$initConfig = [
+    'ssoBaseUrl' => $block->getUrl('turnto/sso'),
+    'logoutUrl' => $block->getUrl('customer/account/logout'),
+];
 ?>
 <script type="text/javascript">
     (function (window) {
@@ -24,16 +31,14 @@ $siteKey = $block->getSiteKey();
 <script type="text/x-magento-init">
     {
         "*": {
-            "turnToConfig": {}
+            "turnToConfig": <?= /* @noEscape */ json_encode($initConfig) ?>
         }
     }
-
 </script>
 
 
-<?php if ($siteKey): ?>
-    <script src="<?= $block->getConfigValue(Config::PRODUCT_WIDGET_URL) ?><?= Config::SOCIALCOMMERCE_VERSION ?>/widgets/<?= $siteKey ?>/js/turnto.js"
-            type="text/javascript" async></script>
+<?php if ($widgetUrl): ?>
+    <script src="<?= $block->escapeUrl($widgetUrl) ?>" type="text/javascript" async></script>
 <?php endif; ?>
 
 <?= $block->getChildHtml() ?>

--- a/view/frontend/web/js/turnto-config.js
+++ b/view/frontend/web/js/turnto-config.js
@@ -1,76 +1,139 @@
 /**
- * TurnTo_SocialCommerce
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/osl-3.0.php
- *
- * @copyright  Copyright (c) 2018 TurnTo Networks, Inc.
- * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * Copyright © Emplifi, Inc. All rights reserved.
+ * See COPYING.txt for license details.
  */
 define([
     'jquery',
 ], function ($) {
     'use strict';
+
     return function (config) {
+        const moduleConfig = config || {};
+        const ttSsoBaseUrl = moduleConfig.ssoBaseUrl ? moduleConfig.ssoBaseUrl.replace(/\/+$/, '') + '/' : '';
+        const ttLogoutUrl = moduleConfig.logoutUrl || '';
 
-
-        if (window.turnToConfig.hasOwnProperty('sso')
-        ) {
-            window.turnToConfig.sso.userDataFn = function (contextObj) {
-                $.get(window.turnToConfig.baseUrl + 'turnto/sso/getuserstatus')
-                    .done(function (data) {
-                        if (data.jwt === null) {
-                            //user is logged out - redirect to login with message
-                            let context = JSON.parse(atob(contextObj));
-                            window.sessionStorage.setItem('contextObj', contextObj)
-                            window.location.replace("/turnto/sso/redirecttologin/action/" + context.action + '/authSetting/' + context.authSetting);
-                        } else if (window.sessionStorage.getItem('contextObj')) {
-                           //if user is coming from a log in redirect and the review window is triggered manually - use old context obj
-                           window.TurnToCmd('ssoRegDone', {context: window.sessionStorage.getItem('contextObj'), userDataToken: data.jwt});
-                            window.sessionStorage.removeItem('contextObj')
-                        } else {
-                         window.TurnToCmd('ssoRegDone', {context: contextObj, userDataToken: data.jwt});
-                        }
-                    })
-                    .fail(function () {
-                         window.TurnToCmd('ssoRegDone', {context: contextObj, userDataToken: null});
-                    });
-
-            };
-
-            //When a user is redirected to PDP after login
-            if(window.sessionStorage.getItem('contextObj')){
-                $.get(window.turnToConfig.baseUrl + 'turnto/sso/getuserstatus')
-                    .done(function (data){
-                        window.TurnToCmd('ssoRegDone', {context: window.sessionStorage.getItem('contextObj'), userDataToken: data.jwt});
-                        window.sessionStorage.removeItem('contextObj');
-                    })
-                    .fail(function(){
-                        window.TurnToCmd('ssoRegDone', {context: window.sessionStorage.getItem('contextObj'), userDataToken: null});
-                        window.sessionStorage.removeItem('contextObj');
-                    });
-            }
-
-            window.turnToConfig.sso.loggedInDataFn = function(contextObj) {
-                $.get(window.turnToConfig.baseUrl + 'turnto/sso/loggedindata')
-                    .done(function (data) {
-                        window.TurnToCmd('loggedInDataFnDone', {context: contextObj, userDataToken: data.jwt});
-                    })
-                    .fail(function () {
-                        window.TurnToCmd('loggedInDataFnDone', {context: contextObj, userDataToken: null});
-                    })
-            };
-
-            window.turnToConfig.sso.logout =  function() {
-                window.location.replace("/customer/account/logout");
-            };
-
+        if (!window.turnToConfig || !window.turnToConfig.hasOwnProperty('sso')) {
+            return;
         }
 
+        const normalizeSsoResponse = function (response) {
+            if (!response || typeof response !== 'object' || Array.isArray(response)) {
+                throw new Error('Malformed SSO response: expected a JSON object.');
+            }
 
+            if (!Object.prototype.hasOwnProperty.call(response, 'jwt')) {
+                throw new Error('Malformed SSO response: missing jwt field.');
+            }
+
+            return {
+                success: response.success ?? (response.jwt !== null),
+                loggedIn: response.logged_in ?? (response.jwt !== null),
+                jwt: response.jwt,
+                error: response.error && typeof response.error === 'object' ? response.error : null
+            };
+        };
+
+        const ssoGet = function (url) {
+            return $.get(url).then(function (response) {
+                return normalizeSsoResponse(response);
+            });
+        };
+
+        const logSsoError = function (response) {
+            if (response && response.error && response.error.code) {
+                console.warn(
+                    'TurnTo SSO response warning:',
+                    response.error.code,
+                    response.error.message || ''
+                );
+            }
+        };
+
+        const getSsoFailMessage = function (jqXhrOrError, textStatus, errorThrown) {
+            if (errorThrown) {
+                return errorThrown;
+            }
+
+            if (textStatus && typeof textStatus === 'string') {
+                return textStatus;
+            }
+
+            if (jqXhrOrError instanceof Error) {
+                return jqXhrOrError.message || 'Unknown SSO error';
+            }
+
+            if (jqXhrOrError && jqXhrOrError.responseJSON && jqXhrOrError.responseJSON.message) {
+                return jqXhrOrError.responseJSON.message;
+            }
+
+            if (jqXhrOrError && jqXhrOrError.responseText) {
+                return jqXhrOrError.responseText;
+            }
+
+            return 'Unknown SSO error';
+        };
+
+        window.turnToConfig.sso.userDataFn = function (contextObj) {
+            ssoGet(ttSsoBaseUrl + 'getuserstatus')
+                .done(function (response) {
+                    logSsoError(response);
+                    if (response.loggedIn === false) {
+                        //user is logged out - redirect to login with message
+                        let context = JSON.parse(atob(contextObj));
+                        window.sessionStorage.setItem('contextObj', contextObj)
+                        window.location.replace(
+                            ttSsoBaseUrl + 'redirecttologin/action/'
+                            + encodeURIComponent(context.action) + '/authSetting/' + encodeURIComponent(context.authSetting)
+                        );
+                        return;
+                    }
+
+                    if (response.jwt && typeof response.jwt === 'string') {
+                        window.TurnToCmd('ssoRegDone', {context: contextObj, userDataToken: response.jwt});
+                        window.sessionStorage.removeItem('contextObj')
+                    } else {
+                        console.warn('TurnTo SSO request failed to return jwt');
+                        window.sessionStorage.setItem('contextObj', contextObj)
+                    }
+                })
+                .fail(function (jqXhr, textStatus, errorThrown) {
+                    console.warn('TurnTo SSO request failed: getuserstatus', getSsoFailMessage(jqXhr, textStatus, errorThrown));
+                    window.sessionStorage.setItem('contextObj', contextObj)
+                });
+        };
+
+        //When a user is redirected to PDP after login
+        if(window.sessionStorage.getItem('contextObj')){
+            ssoGet(ttSsoBaseUrl + 'getuserstatus')
+                .done(function (response){
+                    logSsoError(response);
+                    if (response.jwt && typeof response.jwt === 'string') {
+                        //if user is coming from a log in redirect and the review window is triggered manually - use old context obj
+                        window.TurnToCmd('ssoRegDone', {context: window.sessionStorage.getItem('contextObj'), userDataToken: response.jwt});
+                        window.sessionStorage.removeItem('contextObj');
+                    } else {
+                        console.warn('TurnTo SSO request failed to return jwt');
+                    }
+                })
+                .fail(function(jqXhr, textStatus, errorThrown){
+                    console.warn('TurnTo SSO request failed: getuserstatus', getSsoFailMessage(jqXhr, textStatus, errorThrown));
+                });
+        }
+
+        window.turnToConfig.sso.loggedInDataFn = function(contextObj) {
+            ssoGet(ttSsoBaseUrl + 'loggedindata')
+                .done(function (response) {
+                    logSsoError(response);
+                    window.TurnToCmd('loggedInDataFnDone', {context: contextObj, userDataToken: response.jwt});
+                })
+                .fail(function (jqXhr, textStatus, errorThrown) {
+                    window.TurnToCmd('loggedInDataFnDone', {context: contextObj, userDataToken: null});
+                    console.warn('TurnTo SSO request failed: loggedindata', getSsoFailMessage(jqXhr, textStatus, errorThrown));
+                })
+        };
+
+        window.turnToConfig.sso.logout =  function() {
+            window.location.replace(ttLogoutUrl);
+        };
     }
-});
+})


### PR DESCRIPTION
### Summary
This update introduces support for the Commerce Catalog Feed format. It adds a configuration option allowing merchants to select between the existing Google feed format and the new Commerce feed format. Additionally, this update improves product URL resolution logic and introduces the members field to support review sharing for bundle and grouped product types. It also implements a stability and robustness sweep with a focused cleanup around SSO response handling, export flow reliability, and front-end configuration/feed initialization behavior

### Key Changes

- Feed Format Selection: Added a new configuration setting to toggle between Google and Commerce feed formats.
- Commerce Feed Generator: Implemented CommerceFeedGenerator to handle the specific formatting and column requirements of the Commerce feed.
- Members Column for Review Sharing: Added a members field to the Commerce feed. This field outputs a comma-separated list of child SKUs for Bundle and Grouped products, enabling TurnTo to properly share reviews between the collection and its individual simple products.
- Improved Product URL Logic: Refactored URL resolution in Model/Export/Product.php to better handle store-specific URLs and preloaded rewrites.
- Code Refactoring: Abstracted common feed generation logic into AbstractFeedGenerator to keep the Google and Commerce generators DRY.

**SSO reliability and contract hardening**

- Improved SSO controller responses to return structured result payloads (success, logged_in, jwt, optional error) instead of only raw JWT.
- Added explicit SSO error codes via Api/SsoResponseCodeInterface and surfaced them in controller logs.
- FirebaseJwt now validates payload and authorization key before encoding, throwing explicit errors for invalid payload or missing key.
- Frontend SSO JS now normalizes and validates SSO responses, handles malformed responses safely, and logs warning details when issues occur instead of failing silently.
- SSO URL handling in frontend moved to config-injected values and normalized path behavior.
- LogOutSSO and RedirectToLogin clarified redirect handling with explicit setUrl flow.

**Export and import process hardening**

- Refactored shared builders/factories in export/rating paths to avoid stale/shared builder state by switching to builder factories.
- Orders and CanceledOrders feed generation now:
  - Better validates file handle creation and output state,
  - Guards stream handles before close,
  - Adds explicit CSV defaults (including line endings),
  - Uses boolean typed config getters for clearer branching.
- Catalog/Orders/CanceledOrders now use stricter boolean config checks through getConfigBool.
- Ratings import parsing now uses safer XML handling with malformed-data guards, batched SKU lookups, and safer product-update behavior for feed updates/reset.

**Frontend and configuration cleanups**

- Replaced deprecated registry access path with safer locator-based retrieval in ConfigJs.
- Shifted widget URL construction into ViewModel\Widget::getWidgetUrl and passed into turnto-config init flow.
- Updated system XML labels and layout conditions to align naming and visibility behavior for comments-related controls.
- Reduced brittle coupling in TurnToConfig/templates and cleaned JS config/bootstrap initialization paths.

**Configurable product payload improvements**

- Optimized ConfigurablePlugin::afterGetJsonConfig to avoid direct repository lookups and hard failures.
- Added robust JSON deserialization/error handling before mutation.
- Optimized child SKU map generation with safer fallbacks and less repeated work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it refactors the catalog feed generation/transmission pipeline (new formats, batching, DB-based parent/category resolution) and changes SSO/JWT error handling/response contracts, which could impact integrations and scheduled exports.
> 
> **Overview**
> Adds a configurable product feed format option and refactors catalog export to generate/transmit feeds via pluggable `FeedGeneratorInterface` implementations (new tab-delimited *Commerce* feed alongside the existing Google Atom feed), with batching, deterministic product ordering, and preloaded URL rewrites/category paths for performance.
> 
> Hardens several integration edges: SSO endpoints now return structured JSON (`success`, `logged_in`, `jwt`, `error`) with standardized error codes and logging; `FirebaseJwt` now throws on invalid payload/missing auth key. Order/canceled-order exports tighten file/CSV handling, shorten cron lookback windows, and use boolean config getters, while ratings import adds safer XML parsing and batched SKU-to-product loading to reduce per-item lookups.
> 
> Also updates frontend/config blocks and widgets to TurnTo-safe-encode SKUs and improves configurable product JSON config enrichment (safe JSON unserialize + encoded parent/child SKU mapping).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bb506ab339126b83ce9f06201fc0a8f4647da15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->